### PR TITLE
Fix stale data — force-dynamic on all pages

### DIFF
--- a/src/app/(authenticated)/activity/page.tsx
+++ b/src/app/(authenticated)/activity/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic'
+
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
 import { PageHeader } from '@/components/layout/page-header'

--- a/src/app/(authenticated)/dashboard/page.tsx
+++ b/src/app/(authenticated)/dashboard/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic'
+
 import Link from 'next/link'
 import { createClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'

--- a/src/app/(authenticated)/help/page.tsx
+++ b/src/app/(authenticated)/help/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic'
+
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
 import { PageHeader } from '@/components/layout/page-header'

--- a/src/app/(authenticated)/my-time/page.tsx
+++ b/src/app/(authenticated)/my-time/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic'
+
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
 import { PageHeader } from '@/components/layout/page-header'

--- a/src/app/(authenticated)/projects/[id]/page.tsx
+++ b/src/app/(authenticated)/projects/[id]/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic'
+
 import { notFound, redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
 import { PageHeader } from '@/components/layout/page-header'

--- a/src/app/(authenticated)/projects/page.tsx
+++ b/src/app/(authenticated)/projects/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic'
+
 import Link from 'next/link'
 import { createClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'

--- a/src/app/(authenticated)/reports/page.tsx
+++ b/src/app/(authenticated)/reports/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic'
+
 import { Suspense } from 'react'
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'

--- a/src/app/(authenticated)/schedule/page.tsx
+++ b/src/app/(authenticated)/schedule/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic'
+
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
 import { PageHeader } from '@/components/layout/page-header'

--- a/src/app/(authenticated)/settings/page.tsx
+++ b/src/app/(authenticated)/settings/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic'
+
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
 import { PageHeader } from '@/components/layout/page-header'

--- a/src/app/(authenticated)/templates/page.tsx
+++ b/src/app/(authenticated)/templates/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic'
+
 import Link from 'next/link'
 import { createClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'


### PR DESCRIPTION
## Summary
Time entries, reports, My Time, and project detail were showing empty/stale data because Vercel cached the server component responses. This adds `export const dynamic = 'force-dynamic'` to all 10 authenticated pages so every page load hits the database fresh.

## Test plan
- [ ] Clock in/out on a project — time entry appears in Time Log immediately
- [ ] Check My Time — shows weekly total and entries
- [ ] Check Reports — shows all time entries with no filters
- [ ] Dashboard stats match actual data

🤖 Generated with [Claude Code](https://claude.com/claude-code)