### PR TITLE
Fix all heading text colors, photo upload compression, add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,34 @@
-@AGENTS.md
+# Blue Shores PM
+
+## Project Context
+Custom project management app for Blue Shores Electric (Joe Lopez).
+- **Live:** https://blue-shores-pm.vercel.app
+- **Stack:** Next.js 16 + Supabase + Cloudflare R2 + Vercel
+- **Supabase project:** jhznaijckdrokjpglwpp (us-east-1)
+- **R2 bucket:** blue-shores
+
+## Git Workflow
+- **Never push directly to main.** Always create a feature branch, push it, create a PR, and wait for Kenny's approval before merging.
+- **Before creating a branch:** `git checkout main && git pull origin main && git checkout -b feat/...`
+- **Always use Squash and merge** in the GitHub UI.
+- **Never merge a PR without Kenny's explicit approval.**
+- **Never prioritize speed over process.** Follow these rules every time, no exceptions.
+
+## Vercel Deployment
+- Production deploys when main is updated (auto via GitHub integration)
+- Preview deploys on branch push
+- All env vars must be set for both `production` AND `preview` environments
+
+## Code Standards
+- Brand color: `#68BD45` (green) — no blue anywhere in the app
+- Dark sidebar/login: `#32373C`
+- All text on light backgrounds must be `text-gray-500` minimum — never use `text-gray-300` or `text-gray-400` on white/gray-50 backgrounds
+- All headings must have explicit `text-gray-900`
+- All pages must have `export const dynamic = 'force-dynamic'` to prevent stale data
+- Secure every endpoint — auth check + RLS
+- Photos compress client-side before upload (Vercel 4.5MB body limit)
+
+## Testing
+- Run `npm run test:run` before every commit
+- Run `npm run build` before every push
+- 53+ tests must pass

--- a/src/app/(authenticated)/my-time/page.tsx
+++ b/src/app/(authenticated)/my-time/page.tsx
@@ -41,7 +41,7 @@ export default async function MyTimePage() {
         </Card>
 
         <div>
-          <h2 className="text-lg font-semibold mb-3">Recent Entries</h2>
+          <h2 className="text-lg font-semibold text-gray-900 mb-3">Recent Entries</h2>
           <TimeEntryList entries={entries ?? []} showUser={false} />
         </div>
       </div>

--- a/src/app/(authenticated)/projects/[id]/client.tsx
+++ b/src/app/(authenticated)/projects/[id]/client.tsx
@@ -247,7 +247,7 @@ export function ProjectDetailClient({
 
       {/* Notes section */}
       <div>
-        <h2 className="text-lg font-semibold mb-3">Notes</h2>
+        <h2 className="text-lg font-semibold text-gray-900 mb-3">Notes</h2>
         <NoteList notes={notes} />
         <div className="mt-3 hidden md:block">
           <NoteForm onSubmit={handleAddNote} />
@@ -256,7 +256,7 @@ export function ProjectDetailClient({
 
       {/* Photos section */}
       <div>
-        <h2 className="text-lg font-semibold mb-3">Photos</h2>
+        <h2 className="text-lg font-semibold text-gray-900 mb-3">Photos</h2>
         <PhotoGallery
           photos={photos}
           onDelete={isAdmin ? handleDeletePhoto : undefined}
@@ -267,7 +267,7 @@ export function ProjectDetailClient({
       {/* Expenses section */}
       <div>
         <div className="flex items-center justify-between mb-3">
-          <h2 className="text-lg font-semibold">Expenses</h2>
+          <h2 className="text-lg font-semibold text-gray-900">Expenses</h2>
           <Button variant="ghost" size="sm" onClick={() => setShowExpenseModal(true)} className="hidden md:inline-flex">
             + Add Expense
           </Button>
@@ -283,7 +283,7 @@ export function ProjectDetailClient({
       {/* Inspections section */}
       <div>
         <div className="flex items-center justify-between mb-3">
-          <h2 className="text-lg font-semibold">Inspections</h2>
+          <h2 className="text-lg font-semibold text-gray-900">Inspections</h2>
           {isAdmin && (
             <Button variant="ghost" size="sm" onClick={() => setShowInspectionModal(true)} className="hidden md:inline-flex">
               + Add Inspection
@@ -303,7 +303,7 @@ export function ProjectDetailClient({
       {/* Time entries section */}
       <div>
         <div className="flex items-center justify-between mb-3">
-          <h2 className="text-lg font-semibold">Time Log</h2>
+          <h2 className="text-lg font-semibold text-gray-900">Time Log</h2>
           <Button variant="ghost" size="sm" onClick={() => setShowTimeModal(true)} className="hidden md:inline-flex">
             + Manual Entry
           </Button>

--- a/src/app/(authenticated)/projects/[id]/plans/page.tsx
+++ b/src/app/(authenticated)/projects/[id]/plans/page.tsx
@@ -73,7 +73,7 @@ export default async function PlansPage({
                     <div className="flex items-center gap-3">
                       <FileImage className="w-8 h-8 text-[#68BD45]" />
                       <div>
-                        <h3 className="font-medium">{plan.name}</h3>
+                        <h3 className="font-medium text-gray-900">{plan.name}</h3>
                         <p className="text-xs text-gray-500">
                           v{plan.version} — {formatDate(new Date(plan.created_at))}
                         </p>

--- a/src/app/(authenticated)/settings/client.tsx
+++ b/src/app/(authenticated)/settings/client.tsx
@@ -43,7 +43,7 @@ export function SettingsClient({ users, notificationPreferences, userId }: Setti
       <NotificationSettings preferences={notificationPreferences} userId={userId} />
 
       <Card>
-        <h2 className="font-semibold mb-3">Invite Crew Members</h2>
+        <h2 className="font-semibold text-gray-900 mb-3">Invite Crew Members</h2>
         <p className="text-sm text-gray-500 mb-3">
           Share this link with crew members to let them create an account.
         </p>
@@ -59,7 +59,7 @@ export function SettingsClient({ users, notificationPreferences, userId }: Setti
       </Card>
 
       <div>
-        <h2 className="font-semibold mb-3">Team ({users.length})</h2>
+        <h2 className="font-semibold text-gray-900 mb-3">Team ({users.length})</h2>
         <div className="space-y-2">
           {users.map((u) => (
             <Card key={u.id}>

--- a/src/app/api/storage/upload/route.ts
+++ b/src/app/api/storage/upload/route.ts
@@ -5,6 +5,8 @@ import { uploadToR2 } from '@/lib/r2'
 // Accept any image/* type + PDF for blueprints
 const MAX_SIZE = 50 * 1024 * 1024 // 50MB (covers both photos and plans)
 
+export const maxDuration = 30 // Allow up to 30s for large uploads
+
 export async function POST(request: Request) {
   // Auth check
   const supabase = await createClient()
@@ -30,8 +32,13 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'File too large' }, { status: 400 })
   }
 
-  const buffer = Buffer.from(await file.arrayBuffer())
-  await uploadToR2(key, buffer, file.type)
-
-  return NextResponse.json({ key })
+  try {
+    const buffer = Buffer.from(await file.arrayBuffer())
+    await uploadToR2(key, buffer, file.type)
+    return NextResponse.json({ key })
+  } catch (err) {
+    console.error('R2 upload failed:', err)
+    const message = err instanceof Error ? err.message : 'Upload to storage failed'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
 }

--- a/src/components/field/note-list.tsx
+++ b/src/components/field/note-list.tsx
@@ -20,7 +20,7 @@ export function NoteList({ notes }: NoteListProps) {
         <div key={note.id} className="bg-gray-50 rounded-lg p-3">
           <p className="text-sm text-gray-800 whitespace-pre-wrap">{note.content}</p>
           <div className="flex items-center gap-2 mt-2 text-xs text-gray-500">
-            <span className="font-medium">{note.profiles?.name ?? 'Unknown'}</span>
+            <span className="font-medium text-gray-700">{note.profiles?.name ?? 'Unknown'}</span>
             <span>{formatDate(new Date(note.created_at))}</span>
           </div>
         </div>

--- a/src/components/settings/notification-settings.tsx
+++ b/src/components/settings/notification-settings.tsx
@@ -106,7 +106,7 @@ export function NotificationSettings({ preferences, userId }: NotificationSettin
     <Card>
       <div className="flex items-center gap-2 mb-4">
         <Bell className="w-5 h-5 text-[#68BD45]" />
-        <h2 className="font-semibold">Notifications</h2>
+        <h2 className="font-semibold text-gray-900">Notifications</h2>
       </div>
 
       {!hasSubscription && (

--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -36,7 +36,7 @@ export function Modal({ open, onClose, title, children, className }: ModalProps)
       )}
     >
       <div className="flex items-center justify-between p-4 border-b border-gray-200">
-        <h2 className="text-lg font-semibold">{title}</h2>
+        <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
         <button
           onClick={onClose}
           className="p-1 rounded-lg hover:bg-gray-100 transition-colors"

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -29,20 +29,28 @@ export async function uploadPhoto(
   }
 
   const timestamp = Date.now()
-  const ext = MIME_TO_EXT[file.type] ?? 'jpg'
-  const path = `projects/${projectId}/photos/${timestamp}.${ext}`
+  const path = `projects/${projectId}/photos/${timestamp}.jpg`
   const thumbnailPath = `projects/${projectId}/photos/thumb_${timestamp}.jpg`
 
-  // Upload original to R2
-  await uploadToR2(path, file)
+  // Compress the photo client-side before uploading
+  // Vercel has a ~4.5MB body limit on serverless functions
+  // iPhone photos are often 5-15MB, so we resize to max 2048px and compress as JPEG
+  let uploadFile: File | Blob = file
+  try {
+    uploadFile = await compressImage(file, 2048, 0.85)
+  } catch {
+    // If compression fails (HEIC on some browsers), upload original
+  }
 
-  // Create and upload thumbnail (best-effort — HEIC/HEIF may not render in canvas)
+  // Upload compressed photo to R2
+  await uploadToR2(path, uploadFile)
+
+  // Create and upload thumbnail (best-effort)
   try {
     const thumbnailBlob = await createThumbnail(file, 300)
     await uploadToR2(thumbnailPath, thumbnailBlob)
     return { path, thumbnailPath }
   } catch {
-    // Thumbnail failed (unsupported format on this browser) — use original as fallback
     return { path, thumbnailPath: path }
   }
 }
@@ -118,6 +126,44 @@ async function createThumbnail(file: File, maxSize: number): Promise<Blob> {
     }
 
     img.onerror = () => reject(new Error('Failed to load image'))
+    img.src = url
+  })
+}
+
+async function compressImage(file: File, maxDimension: number, quality: number): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    const img = new Image()
+    const url = URL.createObjectURL(file)
+
+    img.onload = () => {
+      URL.revokeObjectURL(url)
+      const canvas = document.createElement('canvas')
+      const ctx = canvas.getContext('2d')
+      if (!ctx) return reject(new Error('Canvas not supported'))
+
+      let { width, height } = img
+      if (width > maxDimension || height > maxDimension) {
+        if (width > height) {
+          height = (height * maxDimension) / width
+          width = maxDimension
+        } else {
+          width = (width * maxDimension) / height
+          height = maxDimension
+        }
+      }
+
+      canvas.width = width
+      canvas.height = height
+      ctx.drawImage(img, 0, 0, width, height)
+
+      canvas.toBlob(
+        (blob) => (blob ? resolve(blob) : reject(new Error('Failed to compress image'))),
+        'image/jpeg',
+        quality
+      )
+    }
+
+    img.onerror = () => reject(new Error('Failed to load image for compression'))
     img.src = url
   })
 }


### PR DESCRIPTION
## Summary
- **Text readability** — added explicit `text-gray-900` to ALL section headings across project detail (Notes, Photos, Expenses, Inspections, Time Log), My Time, modal titles, settings, notification header, plan names
- **Photo upload fix** — compresses photos client-side before upload (max 2048px, 85% JPEG). Vercel serverless has a 4.5MB body limit and iPhone photos are 5-15MB. Also added proper error handling to R2 upload route.
- **CLAUDE.md** — project-specific rules: git workflow, code standards, deployment process

## Test plan
- [ ] All section headers on project detail page are clearly readable (dark text)
- [ ] Modal titles are dark
- [ ] Settings headings are dark
- [ ] Take a photo from phone camera — should upload successfully now
- [ ] Upload a large photo from desktop — verify compression works

🤖 Generated with [Claude Code](https://claude.com/claude-code)