### PR TITLE
Fix photo upload auth header error on mobile

### DIFF
--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -10,7 +10,12 @@ export async function createClient() {
     {
       cookies: {
         getAll() {
-          return cookieStore.getAll()
+          return cookieStore.getAll().map(cookie => ({
+            ...cookie,
+            // Sanitize cookie values — remove invalid HTTP header characters
+            // Mobile browsers can produce chunked cookies with newlines
+            value: cookie.value.replace(/[\r\n]/g, ''),
+          }))
         },
         setAll(cookiesToSet) {
           try {


### PR DESCRIPTION
## Summary
Photo uploads from mobile were failing with: `Invalid character in header content ["authorization"]`

iOS Safari produces chunked Supabase auth cookies with newline characters (`\r\n`) that break HTTP header validation when the server-side Supabase client sends the authorization header to Supabase's API.

Fix: sanitize cookie values by stripping `\r\n` characters when reading them in the server client.

## Test plan
- [ ] Take a photo from iPhone camera in the app — should upload successfully
- [ ] Take a photo from Android camera — should upload successfully
- [ ] Upload a photo from desktop — should still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)