### PR TITLE
Fix photo upload — exclude API routes from auth middleware

### DIFF
--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -10,7 +10,10 @@ export async function updateSession(request: NextRequest) {
     {
       cookies: {
         getAll() {
-          return request.cookies.getAll()
+          return request.cookies.getAll().map(cookie => ({
+            ...cookie,
+            value: cookie.value.replace(/[\r\n\0]/g, ''),
+          }))
         },
         setAll(cookiesToSet) {
           cookiesToSet.forEach(({ name, value }) =>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -7,6 +7,6 @@ export async function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
-    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+    '/((?!_next/static|_next/image|favicon.ico|api/|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
   ],
 }


### PR DESCRIPTION
## Summary
Root cause found: the middleware runs `supabase.auth.getUser()` on EVERY request, including `/api/storage/upload`. iOS Safari auth cookies have characters that break HTTP headers in that Supabase call.

Two fixes:
1. Exclude `api/` routes from the middleware matcher — API routes handle their own auth
2. Sanitize cookies in middleware (strip `\r\n\0`) for page requests too

## Test plan
- [ ] Take photo from iPhone — uploads successfully
- [ ] Take photo from Android — uploads successfully  
- [ ] Pages still redirect to login when not authenticated
- [ ] Authenticated users still redirect away from login page

🤖 Generated with [Claude Code](https://claude.com/claude-code)