### PR TITLE
fix: R2 photo upload with presigned URLs

### DIFF
--- a/docs/superpowers/plans/2026-04-02-r2-photo-upload-fix.md
+++ b/docs/superpowers/plans/2026-04-02-r2-photo-upload-fix.md
@@ -1,0 +1,731 @@
+# R2 Photo Upload Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate all file uploads and reads from Supabase Storage to Cloudflare R2 using presigned URLs, fixing the "Failed to fetch" upload bug on all platforms.
+
+**Architecture:** Browser gets a presigned PUT URL from the API route (cookie-existence auth, no Supabase auth call), then PUTs the file directly to R2. Reads go through an API route that returns R2 signed GET URLs. No Supabase Storage SDK involvement.
+
+**Tech Stack:** Cloudflare R2 (S3-compatible), `@aws-sdk/client-s3`, `@aws-sdk/s3-request-presigner`, Next.js API routes
+
+**Spec:** `docs/superpowers/specs/2026-04-02-r2-photo-upload-fix-design.md`
+
+---
+
+## File Map
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `scripts/setup-r2-cors.ts` | Create | One-time script to set CORS on R2 bucket |
+| `src/lib/storage.ts` | Rewrite | Remove Supabase dependency, use presigned R2 URLs |
+| `src/app/api/storage/signed-url/route.ts` | Modify | Cookie-existence auth instead of `supabase.auth.getUser()` |
+| `src/app/api/storage/presign/route.ts` | No change | Already correct |
+| `src/app/(authenticated)/projects/[id]/client.tsx` | Modify | Remove supabase arg from upload, add error check on insert |
+| `src/components/field/photo-gallery.tsx` | Modify | Remove supabase arg from getSignedUrl |
+| `src/components/field/expense-form.tsx` | Modify | Remove supabase arg from uploadPhoto |
+| `src/components/field/expense-list.tsx` | Modify | Remove supabase arg from getSignedUrl |
+| `src/components/annotation/plan-upload.tsx` | Modify | Remove supabase arg from uploadPlanFile, fix auth check |
+| `src/components/annotation/plan-canvas.tsx` | Modify | Remove supabase arg from getSignedUrl |
+| `src/lib/offline/sync.ts` | Modify | Use presigned URL upload instead of Supabase Storage |
+
+---
+
+### Task 1: Set R2 CORS Configuration
+
+**Files:**
+- Create: `scripts/setup-r2-cors.ts`
+
+- [ ] **Step 1: Create the CORS setup script**
+
+```typescript
+// scripts/setup-r2-cors.ts
+import { S3Client, PutBucketCorsCommand } from '@aws-sdk/client-s3'
+import * as dotenv from 'dotenv'
+dotenv.config({ path: '.env.local' })
+
+const r2Client = new S3Client({
+  region: 'auto',
+  endpoint: `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+  credentials: {
+    accessKeyId: process.env.R2_ACCESS_KEY_ID!,
+    secretAccessKey: process.env.R2_SECRET_ACCESS_KEY!,
+  },
+})
+
+async function main() {
+  await r2Client.send(
+    new PutBucketCorsCommand({
+      Bucket: process.env.R2_BUCKET ?? 'blue-shores',
+      CORSConfiguration: {
+        CORSRules: [
+          {
+            AllowedOrigins: [
+              'https://blue-shores-pm.vercel.app',
+              'http://localhost:3000',
+            ],
+            AllowedMethods: ['PUT', 'GET'],
+            AllowedHeaders: ['Content-Type', 'Content-Length'],
+            ExposeHeaders: ['ETag'],
+            MaxAgeSeconds: 86400,
+          },
+        ],
+      },
+    })
+  )
+  console.log('R2 CORS configured successfully')
+}
+
+main().catch((err) => {
+  console.error('Failed to set CORS:', err)
+  process.exit(1)
+})
+```
+
+- [ ] **Step 2: Run the script**
+
+```bash
+npx tsx scripts/setup-r2-cors.ts
+```
+
+Expected: `R2 CORS configured successfully`
+
+- [ ] **Step 3: Verify CORS with curl**
+
+```bash
+curl -I -X OPTIONS \
+  -H "Origin: https://blue-shores-pm.vercel.app" \
+  -H "Access-Control-Request-Method: PUT" \
+  -H "Access-Control-Request-Headers: Content-Type" \
+  "https://3a749b288715efe8fa86dadeee7ccbb1.r2.cloudflarestorage.com/blue-shores/test-cors"
+```
+
+Expected: Response includes `Access-Control-Allow-Origin: https://blue-shores-pm.vercel.app` and `Access-Control-Allow-Methods` containing `PUT`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/setup-r2-cors.ts
+git commit -m "feat: add R2 CORS setup script"
+```
+
+---
+
+### Task 2: Rewrite `storage.ts` to Use R2 Presigned URLs
+
+**Files:**
+- Rewrite: `src/lib/storage.ts`
+
+The key change: remove the `SupabaseClient` parameter from all functions. Uploads go through the presign API route → direct PUT to R2. Reads go through the signed-url API route.
+
+- [ ] **Step 1: Rewrite storage.ts**
+
+```typescript
+// src/lib/storage.ts
+// Photo & plan storage via Cloudflare R2
+// Uploads: browser gets presigned PUT URL from API route, PUTs directly to R2
+// Reads: browser gets signed GET URL from API route
+
+const MAX_PHOTO_SIZE = 20 * 1024 * 1024 // 20MB
+
+async function getPresignedUploadUrl(
+  key: string,
+  contentType: string
+): Promise<string> {
+  const res = await fetch('/api/storage/presign', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ key, contentType }),
+  })
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ error: res.statusText }))
+    throw new Error(body.error ?? `Presign failed: ${res.status}`)
+  }
+  const { uploadUrl } = await res.json()
+  return uploadUrl
+}
+
+async function uploadToR2(
+  key: string,
+  file: File | Blob,
+  contentType: string
+): Promise<void> {
+  const uploadUrl = await getPresignedUploadUrl(key, contentType)
+  const res = await fetch(uploadUrl, {
+    method: 'PUT',
+    body: file,
+    headers: { 'Content-Type': contentType },
+  })
+  if (!res.ok) {
+    throw new Error(`R2 upload failed: ${res.status} ${res.statusText}`)
+  }
+}
+
+export async function uploadPhoto(
+  file: File,
+  projectId: string
+): Promise<{ path: string; thumbnailPath: string }> {
+  if (!file.type.startsWith('image/')) {
+    throw new Error(`File type "${file.type}" is not allowed. Only image files are accepted.`)
+  }
+  if (file.size > MAX_PHOTO_SIZE) {
+    throw new Error(`File size (${(file.size / (1024 * 1024)).toFixed(1)} MB) exceeds the 20 MB limit.`)
+  }
+
+  const timestamp = Date.now()
+  const path = `projects/${projectId}/photos/${timestamp}.jpg`
+  const thumbnailPath = `projects/${projectId}/photos/thumb_${timestamp}.jpg`
+
+  // Compress the photo client-side before uploading
+  let uploadFile: File | Blob = file
+  try {
+    uploadFile = await compressImage(file, 2048, 0.85)
+  } catch {
+    // If compression fails (HEIC on some browsers), upload original
+  }
+
+  await uploadToR2(path, uploadFile, 'image/jpeg')
+
+  // Create and upload thumbnail (best-effort)
+  try {
+    const thumbnailBlob = await createThumbnail(file, 300)
+    await uploadToR2(thumbnailPath, thumbnailBlob, 'image/jpeg')
+    return { path, thumbnailPath }
+  } catch {
+    return { path, thumbnailPath: path }
+  }
+}
+
+export async function uploadPlanFile(
+  file: File | Blob,
+  key: string
+): Promise<void> {
+  const contentType = file instanceof File ? file.type : 'image/png'
+  await uploadToR2(key, file, contentType)
+}
+
+export async function getSignedUrl(
+  path: string,
+  expiresIn = 3600
+): Promise<string> {
+  const res = await fetch(
+    `/api/storage/signed-url?key=${encodeURIComponent(path)}&expiresIn=${expiresIn}`
+  )
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ error: res.statusText }))
+    throw new Error(body.error ?? `Failed to get signed URL: ${res.status}`)
+  }
+  const { url } = await res.json()
+  return url
+}
+
+async function createThumbnail(file: File | Blob, maxSize: number): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    const img = new Image()
+    const url = URL.createObjectURL(file)
+
+    img.onload = () => {
+      URL.revokeObjectURL(url)
+      const canvas = document.createElement('canvas')
+      const ctx = canvas.getContext('2d')
+      if (!ctx) return reject(new Error('Canvas not supported'))
+
+      let { width, height } = img
+      if (width > height) {
+        if (width > maxSize) {
+          height = (height * maxSize) / width
+          width = maxSize
+        }
+      } else {
+        if (height > maxSize) {
+          width = (width * maxSize) / height
+          height = maxSize
+        }
+      }
+
+      canvas.width = width
+      canvas.height = height
+      ctx.drawImage(img, 0, 0, width, height)
+
+      canvas.toBlob(
+        (blob) => (blob ? resolve(blob) : reject(new Error('Failed to create thumbnail'))),
+        'image/jpeg',
+        0.7
+      )
+    }
+
+    img.onerror = () => reject(new Error('Failed to load image'))
+    img.src = url
+  })
+}
+
+async function compressImage(file: File, maxDimension: number, quality: number): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    const img = new Image()
+    const url = URL.createObjectURL(file)
+
+    img.onload = () => {
+      URL.revokeObjectURL(url)
+      const canvas = document.createElement('canvas')
+      const ctx = canvas.getContext('2d')
+      if (!ctx) return reject(new Error('Canvas not supported'))
+
+      let { width, height } = img
+      if (width > maxDimension || height > maxDimension) {
+        if (width > height) {
+          height = (height * maxDimension) / width
+          width = maxDimension
+        } else {
+          width = (width * maxDimension) / height
+          height = maxDimension
+        }
+      }
+
+      canvas.width = width
+      canvas.height = height
+      ctx.drawImage(img, 0, 0, width, height)
+
+      canvas.toBlob(
+        (blob) => (blob ? resolve(blob) : reject(new Error('Failed to compress image'))),
+        'image/jpeg',
+        quality
+      )
+    }
+
+    img.onerror = () => reject(new Error('Failed to load image for compression'))
+    img.src = url
+  })
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/lib/storage.ts
+git commit -m "feat: rewrite storage.ts to use R2 presigned URLs"
+```
+
+---
+
+### Task 3: Fix `signed-url/route.ts` Auth
+
+**Files:**
+- Modify: `src/app/api/storage/signed-url/route.ts`
+
+Replace `supabase.auth.getUser()` with cookie-existence check (same pattern as the presign route). This avoids the iOS cookie header bug and is consistent with the presign route.
+
+- [ ] **Step 1: Rewrite the route**
+
+Replace the entire file with:
+
+```typescript
+import { NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import { getR2SignedUrl } from '@/lib/r2'
+
+export async function GET(request: Request) {
+  // Cookie-existence auth — avoids supabase.auth.getUser() which
+  // breaks on iOS due to invalid characters in auth cookies
+  const cookieStore = await cookies()
+  const authCookie = cookieStore.getAll().find(c =>
+    c.name.includes('auth-token') || c.name.includes('sb-')
+  )
+
+  if (!authCookie) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { searchParams } = new URL(request.url)
+  const key = searchParams.get('key')
+  const expiresIn = parseInt(searchParams.get('expiresIn') ?? '3600', 10)
+
+  if (!key) {
+    return NextResponse.json({ error: 'Missing key' }, { status: 400 })
+  }
+
+  try {
+    const url = await getR2SignedUrl(key, expiresIn)
+    return NextResponse.json({ url })
+  } catch (err) {
+    console.error('Signed URL failed:', err)
+    return NextResponse.json({ error: 'Failed to generate signed URL' }, { status: 500 })
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/app/api/storage/signed-url/route.ts
+git commit -m "fix: signed-url route uses cookie-existence auth"
+```
+
+---
+
+### Task 4: Update All Upload Consumers
+
+**Files:**
+- Modify: `src/app/(authenticated)/projects/[id]/client.tsx`
+- Modify: `src/components/field/expense-form.tsx`
+- Modify: `src/components/annotation/plan-upload.tsx`
+
+All three files call `uploadPhoto(supabase, file, projectId)` or `uploadPlanFile(supabase, file, key)`. The new signatures drop the `supabase` argument.
+
+- [ ] **Step 1: Update `client.tsx` photo upload**
+
+In `src/app/(authenticated)/projects/[id]/client.tsx`:
+
+Change line 138 from:
+```typescript
+      const { path, thumbnailPath } = await uploadPhoto(supabase, file, project.id)
+```
+to:
+```typescript
+      const { path, thumbnailPath } = await uploadPhoto(file, project.id)
+```
+
+Also add error checking on the DB insert. Change lines 139-145 from:
+```typescript
+      await supabase.from('photos').insert({
+        user_id: userId,
+        file_path: path,
+        thumbnail_path: thumbnailPath,
+        linked_type: 'project',
+        linked_id: project.id,
+      })
+```
+to:
+```typescript
+      const { error: insertError } = await supabase.from('photos').insert({
+        user_id: userId,
+        file_path: path,
+        thumbnail_path: thumbnailPath,
+        linked_type: 'project',
+        linked_id: project.id,
+      })
+      if (insertError) throw new Error(`Failed to save photo record: ${insertError.message}`)
+```
+
+- [ ] **Step 2: Update `expense-form.tsx` receipt upload**
+
+In `src/components/field/expense-form.tsx`:
+
+Change line 46 from:
+```typescript
+        const { path, thumbnailPath } = await uploadPhoto(supabase, receiptFile, projectId)
+```
+to:
+```typescript
+        const { path, thumbnailPath } = await uploadPhoto(receiptFile, projectId)
+```
+
+- [ ] **Step 3: Update `plan-upload.tsx` blueprint upload**
+
+In `src/components/annotation/plan-upload.tsx`:
+
+Change line 48 from:
+```typescript
+      const { data: { user } } = await supabase.auth.getUser()
+```
+to:
+```typescript
+      const { data: { user } } = await supabase.auth.getSession()
+        .then(({ data }) => ({ data: { user: data.session?.user ?? null } }))
+```
+
+Actually, the plan-upload uses `supabase.auth.getUser()` to get the user ID for the DB insert. Since we can't call `getUser()` (broken on iOS), but we need the user ID for the `uploaded_by` column, we should pass `userId` as a prop instead.
+
+Change `plan-upload.tsx` props interface and component:
+
+Add `userId` to the interface:
+```typescript
+interface PlanUploadProps {
+  projectId: string
+  userId: string
+}
+```
+
+Update the component signature:
+```typescript
+export function PlanUpload({ projectId, userId }: PlanUploadProps) {
+```
+
+Remove the `supabase.auth.getUser()` call (lines 48-54) and replace `user.id` with `userId`:
+```typescript
+      setProgress('Uploading...')
+      await uploadPlanFile(uploadFile, filePath)
+
+      setProgress('Saving...')
+
+      const { error: dbError } = await supabase.from('plans').insert({
+        project_id: projectId,
+        name: name.trim(),
+        file_path: filePath,
+        uploaded_by: userId,
+      })
+```
+
+Change line 78 from:
+```typescript
+      await uploadPlanFile(supabase, uploadFile, filePath)
+```
+to:
+```typescript
+      await uploadPlanFile(uploadFile, filePath)
+```
+
+Then find where `PlanUpload` is rendered and pass `userId`. Search for `<PlanUpload` in the codebase and add the `userId` prop.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/\(authenticated\)/projects/\[id\]/client.tsx src/components/field/expense-form.tsx src/components/annotation/plan-upload.tsx
+git commit -m "fix: update all upload consumers for R2 presigned URLs"
+```
+
+---
+
+### Task 5: Update All Read Consumers
+
+**Files:**
+- Modify: `src/components/field/photo-gallery.tsx`
+- Modify: `src/components/field/expense-list.tsx`
+- Modify: `src/components/annotation/plan-canvas.tsx`
+
+All three call `getSignedUrl(supabase, path)`. The new signature is `getSignedUrl(path)`.
+
+- [ ] **Step 1: Update `photo-gallery.tsx`**
+
+In `src/components/field/photo-gallery.tsx`:
+
+Remove the supabase import and hook:
+```typescript
+// Remove: import { useSupabase } from '@/hooks/use-supabase'
+// Remove: const supabase = useSupabase()
+```
+
+Change line 34 from:
+```typescript
+            const url = await getSignedUrl(supabase, path)
+```
+to:
+```typescript
+            const url = await getSignedUrl(path)
+```
+
+Remove `supabase` from the `useEffect` dependency array (line 44):
+```typescript
+  }, [photos])
+```
+
+In the `LightBox` component, remove the supabase hook and update the call:
+```typescript
+// Remove: const supabase = useSupabase()
+```
+
+Change line 171 from:
+```typescript
+    getSignedUrl(supabase, photo.file_path).then(setFullUrl)
+```
+to:
+```typescript
+    getSignedUrl(photo.file_path).then(setFullUrl)
+```
+
+Remove `supabase` from that `useEffect` dependency array:
+```typescript
+  }, [photo])
+```
+
+- [ ] **Step 2: Update `expense-list.tsx`**
+
+In `src/components/field/expense-list.tsx`:
+
+Remove the supabase import and hook:
+```typescript
+// Remove: import { useSupabase } from '@/hooks/use-supabase'
+// Remove: const supabase = useSupabase()
+```
+
+Change line 49 from:
+```typescript
+            const url = await getSignedUrl(supabase, path)
+```
+to:
+```typescript
+            const url = await getSignedUrl(path)
+```
+
+Remove `supabase` from the `useEffect` dependency array.
+
+- [ ] **Step 3: Update `plan-canvas.tsx`**
+
+In `src/components/annotation/plan-canvas.tsx`:
+
+Remove the supabase import and hook (if supabase is still needed for other operations in this file, only remove it from the `getSignedUrl` call):
+```typescript
+// Check if supabase is used elsewhere in the file first
+```
+
+Change line 50 from:
+```typescript
+      const url = await getSignedUrl(supabase, filePath)
+```
+to:
+```typescript
+      const url = await getSignedUrl(filePath)
+```
+
+Remove `supabase` from that `useEffect` dependency array.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/field/photo-gallery.tsx src/components/field/expense-list.tsx src/components/annotation/plan-canvas.tsx
+git commit -m "fix: update all read consumers for R2 signed URLs"
+```
+
+---
+
+### Task 6: Update Offline Sync
+
+**Files:**
+- Modify: `src/lib/offline/sync.ts`
+
+The offline sync uploads photos via `supabase.storage.upload()`. Change it to use the presigned URL flow (the same `uploadToR2` approach). Since offline sync only runs when the device is back online, the presigned URL API route will be accessible.
+
+- [ ] **Step 1: Update the upload_photo case in sync.ts**
+
+Change the `upload_photo` case (around line 47-67) from:
+```typescript
+      case 'upload_photo': {
+        const db = await getDB()
+        const photoRecord = await db.get('photos', op.data.photoId as string)
+        if (photoRecord) {
+          const { error: uploadError } = await supabase.storage
+            .from('project-files')
+            .upload(op.data.filePath as string, photoRecord.blob, {
+              contentType: 'image/jpeg',
+            })
+          if (uploadError) throw uploadError
+```
+to:
+```typescript
+      case 'upload_photo': {
+        const db = await getDB()
+        const photoRecord = await db.get('photos', op.data.photoId as string)
+        if (photoRecord) {
+          // Get presigned URL and upload directly to R2
+          const presignRes = await fetch('/api/storage/presign', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              key: op.data.filePath as string,
+              contentType: 'image/jpeg',
+            }),
+          })
+          if (!presignRes.ok) throw new Error('Failed to get presigned URL')
+          const { uploadUrl } = await presignRes.json()
+
+          const uploadRes = await fetch(uploadUrl, {
+            method: 'PUT',
+            body: photoRecord.blob,
+            headers: { 'Content-Type': 'image/jpeg' },
+          })
+          if (!uploadRes.ok) throw new Error(`R2 upload failed: ${uploadRes.status}`)
+```
+
+The rest of the case (DB insert + cleanup) stays the same.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/lib/offline/sync.ts
+git commit -m "fix: offline sync uses R2 presigned URLs"
+```
+
+---
+
+### Task 7: Find and Pass `userId` to `PlanUpload`
+
+**Files:**
+- Potentially modify: parent component that renders `<PlanUpload>`
+
+- [ ] **Step 1: Find where PlanUpload is rendered**
+
+```bash
+grep -rn "PlanUpload" src/ --include="*.tsx"
+```
+
+Find the parent component and add `userId` prop. The `userId` is typically available from the server component and passed down. Follow the same pattern used for `PhotoCapture`'s `userId` in `client.tsx`.
+
+- [ ] **Step 2: Pass userId to PlanUpload**
+
+In whatever file renders `<PlanUpload projectId={...} />`, change it to:
+```typescript
+<PlanUpload projectId={...} userId={userId} />
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add <modified-file>
+git commit -m "fix: pass userId to PlanUpload component"
+```
+
+---
+
+### Task 8: Clean Up Unused Supabase Storage Imports
+
+**Files:**
+- Modify: any file that still imports `useSupabase` only for storage operations
+
+- [ ] **Step 1: Check for unused imports**
+
+After all changes, grep for files that import `useSupabase` but no longer need it (because storage was the only reason). Remove unused imports.
+
+Also remove `import type { SupabaseClient } from '@supabase/supabase-js'` from `storage.ts` (it was removed in the rewrite but verify).
+
+- [ ] **Step 2: Verify build**
+
+```bash
+npm run build
+```
+
+Expected: Build succeeds with no TypeScript errors. There may be warnings — address any related to the changed files.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A
+git commit -m "chore: remove unused Supabase Storage imports"
+```
+
+---
+
+### Task 9: Deploy and Test
+
+- [ ] **Step 1: Push to a feature branch**
+
+```bash
+git checkout -b fix/r2-photo-upload
+git push -u origin fix/r2-photo-upload
+```
+
+This triggers a Vercel preview deploy.
+
+- [ ] **Step 2: Test on the preview deploy**
+
+1. Log in as Joe (joe@blueshoresnc.com)
+2. Navigate to a project
+3. Click Upload → select an image
+4. Verify: photo uploads without error, appears in the gallery
+5. Click the photo → verify lightbox loads the full image
+6. Test on mobile (iOS Safari) if available
+7. Test blueprint upload
+8. Test expense receipt upload
+
+- [ ] **Step 3: Create PR**
+
+```bash
+gh pr create --title "fix: R2 photo upload with presigned URLs" --body "..."
+```

--- a/docs/superpowers/specs/2026-04-02-r2-photo-upload-fix-design.md
+++ b/docs/superpowers/specs/2026-04-02-r2-photo-upload-fix-design.md
@@ -1,0 +1,115 @@
+# R2 Photo Upload Fix
+
+**Date:** 2026-04-02
+**Status:** Approved
+**Scope:** Bug fix — migrate photo upload/read from broken Supabase Storage to Cloudflare R2
+
+---
+
+## Problem
+
+Photo uploads fail on all platforms (desktop Chrome and iOS) with "Failed to fetch". Three stacked bugs:
+
+1. **R2 CORS** — Browser PUT to R2 via presigned URL is blocked by missing/misconfigured CORS rules on the `blue-shores` bucket.
+2. **signed-url route auth** — `GET /api/storage/signed-url` calls `supabase.auth.getUser()` which triggers the iOS cookie header bug. Even on desktop, this is fragile.
+3. **Silent DB insert failure** — `photos` table insert in `client.tsx` doesn't check the Supabase response for errors, so failed inserts are invisible.
+
+**Evidence:**
+- 2 files exist in Supabase Storage (`storage.objects`) but 0 rows in `photos` table
+- "Failed to fetch" error confirmed on desktop Chrome (screenshot)
+- R2 bucket, API token, and server module (`src/lib/r2.ts`) all exist and work server-side
+
+## Architecture
+
+```
+Browser                          Vercel API              Cloudflare R2
+  |                                  |                        |
+  |-- POST /api/storage/presign ---->|                        |
+  |   (cookie-existence auth)        |-- getR2UploadUrl() --->|
+  |                                  |<-- presigned PUT URL --|
+  |<-- { uploadUrl } ---------------|                        |
+  |                                                           |
+  |-- PUT <presigned URL> ---------------------------------->|
+  |   (file body, no auth header)    |                        |
+  |<-- 200 OK ------------------------------------------------|
+  |                                                           |
+  |-- supabase.from('photos')        |                        |
+  |   .insert({...})                 |                        |
+  |   (browser client, in-memory     |                        |
+  |    token, error checked)         |                        |
+  |                                                           |
+  |-- GET /api/storage/signed-url -->|                        |
+  |   (cookie-existence auth)        |-- getR2SignedUrl() --->|
+  |                                  |<-- signed GET URL -----|
+  |<-- { url } -----------------|                        |
+```
+
+## Changes
+
+### 1. R2 CORS Configuration
+
+Set CORS on the `blue-shores` R2 bucket via S3 `PutBucketCors`:
+
+```json
+{
+  "CORSRules": [{
+    "AllowedOrigins": ["https://blue-shores-pm.vercel.app", "http://localhost:3000"],
+    "AllowedMethods": ["PUT", "GET"],
+    "AllowedHeaders": ["Content-Type", "Content-Length"],
+    "ExposeHeaders": ["ETag"],
+    "MaxAgeSeconds": 86400
+  }]
+}
+```
+
+One-time setup script using the existing `@aws-sdk/client-s3` dependency.
+
+### 2. `src/lib/storage.ts` — Upload via presigned R2 URL
+
+Replace `supabase.storage.upload()` with:
+1. `fetch('/api/storage/presign', { method: 'POST', body: { key, contentType } })` to get presigned URL
+2. `fetch(presignedUrl, { method: 'PUT', body: compressedFile, headers: { 'Content-Type': contentType } })` to upload directly to R2
+
+Same compression/thumbnail logic, just different upload target.
+
+For reading signed URLs: `fetch('/api/storage/signed-url?key=...')` instead of `supabase.storage.createSignedUrl()`.
+
+Remove `SupabaseClient` parameter — functions no longer need the Supabase client for storage operations.
+
+### 3. `src/app/api/storage/signed-url/route.ts` — Fix auth
+
+Replace `supabase.auth.getUser()` with cookie-existence check (same pattern as presign route). This avoids the iOS cookie header bug entirely.
+
+### 4. `src/app/(authenticated)/projects/[id]/client.tsx` — Error check DB insert
+
+```typescript
+const { error: insertError } = await supabase.from('photos').insert({...})
+if (insertError) throw new Error(`Failed to save photo record: ${insertError.message}`)
+```
+
+### 5. `src/components/field/photo-gallery.tsx` — Read via R2
+
+Replace `getSignedUrl(supabase, path)` with `getSignedUrl(path)` (the updated function that calls the API route).
+
+### 6. `src/components/annotation/plan-upload.tsx` — Upload via R2
+
+Update `uploadPlanFile()` call to use the new presigned URL flow.
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `src/lib/storage.ts` | Presigned URL upload, API-based signed URLs |
+| `src/app/api/storage/signed-url/route.ts` | Cookie-existence auth |
+| `src/app/(authenticated)/projects/[id]/client.tsx` | Error checking on photos insert |
+| `src/components/field/photo-gallery.tsx` | Remove Supabase dependency for URLs |
+| `src/components/annotation/plan-upload.tsx` | Use new upload function |
+| `scripts/setup-r2-cors.ts` | One-time CORS setup script |
+
+## Not Changing
+
+- `src/lib/r2.ts` — Already correct, works server-side
+- `src/app/api/storage/presign/route.ts` — Already has cookie-existence auth, already excluded from middleware
+- `src/app/api/storage/upload/route.ts` — Unused (direct upload), keep for potential fallback
+- Supabase Storage bucket — Leave in place, existing files stay
+- RLS policies — Already correct

--- a/scripts/setup-r2-cors.ts
+++ b/scripts/setup-r2-cors.ts
@@ -1,0 +1,58 @@
+// scripts/setup-r2-cors.ts
+import { S3Client, PutBucketCorsCommand } from '@aws-sdk/client-s3'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+// Load .env.local without dotenv dependency
+const envPath = resolve(process.cwd(), '.env.local')
+const envContent = readFileSync(envPath, 'utf-8')
+for (const line of envContent.split('\n')) {
+  const trimmed = line.trim()
+  if (!trimmed || trimmed.startsWith('#')) continue
+  const eqIdx = trimmed.indexOf('=')
+  if (eqIdx === -1) continue
+  const key = trimmed.slice(0, eqIdx).trim()
+  let val = trimmed.slice(eqIdx + 1).trim()
+  // Strip surrounding quotes
+  if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+    val = val.slice(1, -1)
+  }
+  if (!process.env[key]) process.env[key] = val
+}
+
+const r2Client = new S3Client({
+  region: 'auto',
+  endpoint: `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+  credentials: {
+    accessKeyId: process.env.R2_ACCESS_KEY_ID!,
+    secretAccessKey: process.env.R2_SECRET_ACCESS_KEY!,
+  },
+})
+
+async function main() {
+  await r2Client.send(
+    new PutBucketCorsCommand({
+      Bucket: process.env.R2_BUCKET ?? 'blue-shores',
+      CORSConfiguration: {
+        CORSRules: [
+          {
+            AllowedOrigins: [
+              'https://blue-shores-pm.vercel.app',
+              'http://localhost:3000',
+            ],
+            AllowedMethods: ['PUT', 'GET'],
+            AllowedHeaders: ['Content-Type', 'Content-Length'],
+            ExposeHeaders: ['ETag'],
+            MaxAgeSeconds: 86400,
+          },
+        ],
+      },
+    })
+  )
+  console.log('R2 CORS configured successfully')
+}
+
+main().catch((err) => {
+  console.error('Failed to set CORS:', err)
+  process.exit(1)
+})

--- a/src/app/(authenticated)/projects/[id]/client.tsx
+++ b/src/app/(authenticated)/projects/[id]/client.tsx
@@ -135,14 +135,15 @@ export function ProjectDetailClient({
 
   async function handlePhotoCapture(file: File) {
     try {
-      const { path, thumbnailPath } = await uploadPhoto(supabase, file, project.id)
-      await supabase.from('photos').insert({
+      const { path, thumbnailPath } = await uploadPhoto(file, project.id)
+      const { error: insertError } = await supabase.from('photos').insert({
         user_id: userId,
         file_path: path,
         thumbnail_path: thumbnailPath,
         linked_type: 'project',
         linked_id: project.id,
       })
+      if (insertError) throw new Error(`Failed to save photo record: ${insertError.message}`)
       sendNotification('new_photo', 'New Photo', `New photo added to ${project.name}`)
       window.location.reload()
     } catch (err) {

--- a/src/app/(authenticated)/projects/[id]/plans/page.tsx
+++ b/src/app/(authenticated)/projects/[id]/plans/page.tsx
@@ -56,7 +56,7 @@ export default async function PlansPage({
 
       <div className="p-4 md:p-6 space-y-6">
         {/* Upload (admin only) */}
-        {isAdmin && <PlanUpload projectId={id} />}
+        {isAdmin && <PlanUpload projectId={id} userId={user.id} />}
 
         {/* Plans list */}
         <div className="space-y-3">

--- a/src/app/api/storage/signed-url/route.ts
+++ b/src/app/api/storage/signed-url/route.ts
@@ -1,22 +1,32 @@
 import { NextResponse } from 'next/server'
-import { createClient } from '@/lib/supabase/server'
+import { cookies } from 'next/headers'
 import { getR2SignedUrl } from '@/lib/r2'
 
 export async function GET(request: Request) {
-  // Auth check
-  const supabase = await createClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) {
+  // Cookie-existence auth — avoids supabase.auth.getUser() which
+  // breaks on iOS due to invalid characters in auth cookies
+  const cookieStore = await cookies()
+  const authCookie = cookieStore.getAll().find(c =>
+    c.name.includes('auth-token') || c.name.includes('sb-')
+  )
+
+  if (!authCookie) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
   const { searchParams } = new URL(request.url)
   const key = searchParams.get('key')
+  const expiresIn = parseInt(searchParams.get('expiresIn') ?? '3600', 10)
 
   if (!key) {
     return NextResponse.json({ error: 'Missing key' }, { status: 400 })
   }
 
-  const url = await getR2SignedUrl(key)
-  return NextResponse.json({ url })
+  try {
+    const url = await getR2SignedUrl(key, expiresIn)
+    return NextResponse.json({ url })
+  } catch (err) {
+    console.error('Signed URL failed:', err)
+    return NextResponse.json({ error: 'Failed to generate signed URL' }, { status: 500 })
+  }
 }

--- a/src/components/annotation/plan-canvas.tsx
+++ b/src/components/annotation/plan-canvas.tsx
@@ -47,7 +47,7 @@ export function PlanCanvas({ planId, filePath, annotations, userId }: PlanCanvas
 
     // Load background image first, then annotations
     async function loadBackgroundAndAnnotations() {
-      const url = await getSignedUrl(supabase, filePath)
+      const url = await getSignedUrl(filePath)
       const bgImg = await FabricImage.fromURL(url, { crossOrigin: 'anonymous' })
 
       // Scale image to fit canvas
@@ -141,7 +141,7 @@ export function PlanCanvas({ planId, filePath, annotations, userId }: PlanCanvas
       window.removeEventListener('resize', handleResize)
       canvas.dispose()
     }
-  }, [supabase, filePath, annotations])
+  }, [filePath, annotations])
 
   function saveUndoState(canvas: Canvas) {
     const json = JSON.stringify(canvas.toJSON())

--- a/src/components/annotation/plan-upload.tsx
+++ b/src/components/annotation/plan-upload.tsx
@@ -11,9 +11,10 @@ import { uploadPlanFile } from '@/lib/storage'
 
 interface PlanUploadProps {
   projectId: string
+  userId: string
 }
 
-export function PlanUpload({ projectId }: PlanUploadProps) {
+export function PlanUpload({ projectId, userId }: PlanUploadProps) {
   const supabase = useSupabase()
   const router = useRouter()
   const [uploading, setUploading] = useState(false)
@@ -45,14 +46,6 @@ export function PlanUpload({ projectId }: PlanUploadProps) {
     setUploading(true)
 
     try {
-      const { data: { user } } = await supabase.auth.getUser()
-
-      if (!user) {
-        setProgress('Error: Session expired. Please log in again.')
-        setUploading(false)
-        return
-      }
-
       let uploadFile: File | Blob = selectedFile
       let filePath: string
 
@@ -83,7 +76,7 @@ export function PlanUpload({ projectId }: PlanUploadProps) {
         project_id: projectId,
         name: name.trim(),
         file_path: filePath,
-        uploaded_by: user.id,
+        uploaded_by: userId,
       })
 
       if (dbError) throw dbError

--- a/src/components/field/expense-form.tsx
+++ b/src/components/field/expense-form.tsx
@@ -43,7 +43,7 @@ export function ExpenseForm({ projectId, userId, onSuccess }: ExpenseFormProps) 
       let receiptThumbnail: string | null = null
 
       if (receiptFile) {
-        const { path, thumbnailPath } = await uploadPhoto(supabase, receiptFile, projectId)
+        const { path, thumbnailPath } = await uploadPhoto(receiptFile, projectId)
         receiptPath = path
         receiptThumbnail = thumbnailPath
       }

--- a/src/components/field/expense-list.tsx
+++ b/src/components/field/expense-list.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { useSupabase } from '@/hooks/use-supabase'
 import { getSignedUrl } from '@/lib/storage'
 import { formatDate } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
@@ -34,7 +33,6 @@ function formatCurrency(amount: number): string {
 }
 
 export function ExpenseList({ expenses }: ExpenseListProps) {
-  const supabase = useSupabase()
   const [thumbnailUrls, setThumbnailUrls] = useState<Record<string, string>>({})
 
   useEffect(() => {
@@ -46,7 +44,7 @@ export function ExpenseList({ expenses }: ExpenseListProps) {
         expensesWithReceipts.map(async (expense) => {
           try {
             const path = expense.receipt_thumbnail ?? expense.receipt_path!
-            const url = await getSignedUrl(supabase, path)
+            const url = await getSignedUrl(path)
             return [expense.id, url] as const
           } catch {
             return [expense.id, ''] as const
@@ -56,7 +54,7 @@ export function ExpenseList({ expenses }: ExpenseListProps) {
       setThumbnailUrls(Object.fromEntries(entries))
     }
     loadThumbnails()
-  }, [expenses, supabase])
+  }, [expenses])
 
   if (expenses.length === 0) {
     return <p className="text-sm text-gray-500 italic">No expenses yet</p>

--- a/src/components/field/photo-gallery.tsx
+++ b/src/components/field/photo-gallery.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect, useRef } from 'react'
 import { X, Trash2, CheckSquare, Square } from 'lucide-react'
-import { useSupabase } from '@/hooks/use-supabase'
 import { getSignedUrl } from '@/lib/storage'
 import { formatDate } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
@@ -19,7 +18,6 @@ interface PhotoGalleryProps {
 }
 
 export function PhotoGallery({ photos, onDelete, onDeleteMultiple }: PhotoGalleryProps) {
-  const supabase = useSupabase()
   const [selectedPhoto, setSelectedPhoto] = useState<PhotoWithUser | null>(null)
   const [urls, setUrls] = useState<Record<string, string>>({})
   const [selectMode, setSelectMode] = useState(false)
@@ -31,7 +29,7 @@ export function PhotoGallery({ photos, onDelete, onDeleteMultiple }: PhotoGaller
         photos.map(async (photo) => {
           try {
             const path = photo.thumbnail_path ?? photo.file_path
-            const url = await getSignedUrl(supabase, path)
+            const url = await getSignedUrl(path)
             return [photo.id, url] as const
           } catch {
             return [photo.id, ''] as const
@@ -41,7 +39,7 @@ export function PhotoGallery({ photos, onDelete, onDeleteMultiple }: PhotoGaller
       setUrls(Object.fromEntries(entries))
     }
     if (photos.length > 0) loadUrls()
-  }, [photos, supabase])
+  }, [photos])
 
   function toggleSelect(id: string) {
     const next = new Set(selectedIds)
@@ -163,13 +161,12 @@ function LightBox({
   onClose: () => void
   onDelete?: () => void
 }) {
-  const supabase = useSupabase()
   const [fullUrl, setFullUrl] = useState<string>('')
   const overlayRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
-    getSignedUrl(supabase, photo.file_path).then(setFullUrl)
-  }, [photo, supabase])
+    getSignedUrl(photo.file_path).then(setFullUrl)
+  }, [photo])
 
   useEffect(() => {
     overlayRef.current?.focus()

--- a/src/lib/offline/sync.ts
+++ b/src/lib/offline/sync.ts
@@ -48,12 +48,24 @@ export async function processOperation(
         const db = await getDB()
         const photoRecord = await db.get('photos', op.data.photoId as string)
         if (photoRecord) {
-          const { error: uploadError } = await supabase.storage
-            .from('project-files')
-            .upload(op.data.filePath as string, photoRecord.blob, {
+          // Get presigned URL and upload directly to R2
+          const presignRes = await fetch('/api/storage/presign', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              key: op.data.filePath as string,
               contentType: 'image/jpeg',
-            })
-          if (uploadError) throw uploadError
+            }),
+          })
+          if (!presignRes.ok) throw new Error('Failed to get presigned URL')
+          const { uploadUrl } = await presignRes.json()
+
+          const uploadRes = await fetch(uploadUrl, {
+            method: 'PUT',
+            body: photoRecord.blob,
+            headers: { 'Content-Type': 'image/jpeg' },
+          })
+          if (!uploadRes.ok) throw new Error(`R2 upload failed: ${uploadRes.status}`)
 
           // Create photo record in DB
           const { error: dbError } = await supabase.from('photos').insert({

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,27 +1,48 @@
+// src/lib/storage.ts
 // Photo & plan storage via Cloudflare R2
-// Uploads go through /api/storage/upload (server-side, auth-gated)
-// Signed URLs via /api/storage/signed-url (server-side, auth-gated)
+// Uploads: browser gets presigned PUT URL from API route, PUTs directly to R2
+// Reads: browser gets signed GET URL from API route
 
-// Accept any image/* MIME type — covers JPEG, PNG, GIF, WebP, HEIC, HEIF, BMP, TIFF, etc.
-// Android/iPhone cameras all produce image/* types
-const ALLOWED_MIMES_PREFIX = 'image/'
-const MAX_PHOTO_SIZE = 20 * 1024 * 1024 // 20MB (iPhone photos can be large)
+const MAX_PHOTO_SIZE = 20 * 1024 * 1024 // 20MB
 
-const MIME_TO_EXT: Record<string, string> = {
-  'image/jpeg': 'jpg',
-  'image/png': 'png',
-  'image/gif': 'gif',
-  'image/webp': 'webp',
-  'image/heic': 'heic',
-  'image/heif': 'heif',
+async function getPresignedUploadUrl(
+  key: string,
+  contentType: string
+): Promise<string> {
+  const res = await fetch('/api/storage/presign', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ key, contentType }),
+  })
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ error: res.statusText }))
+    throw new Error(body.error ?? `Presign failed: ${res.status}`)
+  }
+  const { uploadUrl } = await res.json()
+  return uploadUrl
+}
+
+async function uploadToR2(
+  key: string,
+  file: File | Blob,
+  contentType: string
+): Promise<void> {
+  const uploadUrl = await getPresignedUploadUrl(key, contentType)
+  const res = await fetch(uploadUrl, {
+    method: 'PUT',
+    body: file,
+    headers: { 'Content-Type': contentType },
+  })
+  if (!res.ok) {
+    throw new Error(`R2 upload failed: ${res.status} ${res.statusText}`)
+  }
 }
 
 export async function uploadPhoto(
-  _supabase: unknown, // kept for API compatibility — not used
   file: File,
   projectId: string
 ): Promise<{ path: string; thumbnailPath: string }> {
-  if (!file.type.startsWith(ALLOWED_MIMES_PREFIX)) {
+  if (!file.type.startsWith('image/')) {
     throw new Error(`File type "${file.type}" is not allowed. Only image files are accepted.`)
   }
   if (file.size > MAX_PHOTO_SIZE) {
@@ -33,8 +54,6 @@ export async function uploadPhoto(
   const thumbnailPath = `projects/${projectId}/photos/thumb_${timestamp}.jpg`
 
   // Compress the photo client-side before uploading
-  // Vercel has a ~4.5MB body limit on serverless functions
-  // iPhone photos are often 5-15MB, so we resize to max 2048px and compress as JPEG
   let uploadFile: File | Blob = file
   try {
     uploadFile = await compressImage(file, 2048, 0.85)
@@ -42,13 +61,12 @@ export async function uploadPhoto(
     // If compression fails (HEIC on some browsers), upload original
   }
 
-  // Upload compressed photo to R2
-  await uploadToR2(path, uploadFile)
+  await uploadToR2(path, uploadFile, 'image/jpeg')
 
   // Create and upload thumbnail (best-effort)
   try {
     const thumbnailBlob = await createThumbnail(file, 300)
-    await uploadToR2(thumbnailPath, thumbnailBlob)
+    await uploadToR2(thumbnailPath, thumbnailBlob, 'image/jpeg')
     return { path, thumbnailPath }
   } catch {
     return { path, thumbnailPath: path }
@@ -59,38 +77,26 @@ export async function uploadPlanFile(
   file: File | Blob,
   key: string
 ): Promise<void> {
-  await uploadToR2(key, file)
-}
-
-async function uploadToR2(key: string, file: File | Blob): Promise<void> {
-  const formData = new FormData()
-  formData.append('file', file)
-  formData.append('key', key)
-
-  const res = await fetch('/api/storage/upload', {
-    method: 'POST',
-    body: formData,
-  })
-
-  if (!res.ok) {
-    const data = await res.json().catch(() => ({ error: 'Upload failed' }))
-    throw new Error(data.error ?? 'Upload failed')
-  }
+  const contentType = file instanceof File ? file.type : 'image/png'
+  await uploadToR2(key, file, contentType)
 }
 
 export async function getSignedUrl(
-  _supabase: unknown, // kept for API compatibility — not used
-  path: string
+  path: string,
+  expiresIn = 3600
 ): Promise<string> {
-  const res = await fetch(`/api/storage/signed-url?key=${encodeURIComponent(path)}`)
+  const res = await fetch(
+    `/api/storage/signed-url?key=${encodeURIComponent(path)}&expiresIn=${expiresIn}`
+  )
   if (!res.ok) {
-    throw new Error('Failed to get signed URL')
+    const body = await res.json().catch(() => ({ error: res.statusText }))
+    throw new Error(body.error ?? `Failed to get signed URL: ${res.status}`)
   }
-  const data = await res.json()
-  return data.url
+  const { url } = await res.json()
+  return url
 }
 
-async function createThumbnail(file: File, maxSize: number): Promise<Blob> {
+async function createThumbnail(file: File | Blob, maxSize: number): Promise<Blob> {
   return new Promise((resolve, reject) => {
     const img = new Image()
     const url = URL.createObjectURL(file)
@@ -120,7 +126,7 @@ async function createThumbnail(file: File, maxSize: number): Promise<Blob> {
 
       canvas.toBlob(
         (blob) => (blob ? resolve(blob) : reject(new Error('Failed to create thumbnail'))),
-        file.type,
+        'image/jpeg',
         0.7
       )
     }


### PR DESCRIPTION
## Summary

- Migrates all file uploads/reads from Supabase Storage to Cloudflare R2 using presigned URLs
- Fixes "Failed to fetch" upload bug on desktop Chrome and iOS Safari
- Fixes silent DB insert failure (photos table insert had no error checking)
- Fixes signed-url route calling `supabase.auth.getUser()` (iOS cookie header bug)

## Root Cause

Three stacked bugs:
1. **R2 CORS** — Browser PUT to R2 blocked by missing CORS rules (fixed in Cloudflare dashboard)
2. **signed-url route auth** — Called `supabase.auth.getUser()` which breaks on iOS due to invalid cookie characters. Now uses cookie-existence check.
3. **Silent DB insert** — `photos` table insert didn't check for errors, so failed inserts were invisible

## Architecture

```
Browser → POST /api/storage/presign → get presigned PUT URL
Browser → PUT directly to R2 (no auth headers, no cookies)
Browser → supabase.from('photos').insert (with error checking)
Browser → GET /api/storage/signed-url → get signed GET URL for reading
```

## Files Changed (13)
- `src/lib/storage.ts` — Rewritten for R2 presigned URLs
- `src/app/api/storage/signed-url/route.ts` — Cookie-existence auth
- `src/app/(authenticated)/projects/[id]/client.tsx` — Error checking + updated calls
- `src/app/(authenticated)/projects/[id]/plans/page.tsx` — Pass userId to PlanUpload
- `src/components/field/photo-gallery.tsx` — R2 signed URLs for reads
- `src/components/field/expense-form.tsx` — Updated upload call
- `src/components/field/expense-list.tsx` — R2 signed URLs for reads
- `src/components/annotation/plan-upload.tsx` — Updated upload + userId prop
- `src/components/annotation/plan-canvas.tsx` — R2 signed URLs for reads
- `src/lib/offline/sync.ts` — Presigned URL upload
- `scripts/setup-r2-cors.ts` — One-time CORS setup script
- `docs/` — Spec and plan docs

## Test plan
- [ ] Upload photo from desktop Chrome
- [ ] Upload photo from iOS Safari
- [ ] Verify photo appears in gallery after upload
- [ ] Verify lightbox loads full-size image
- [ ] Upload blueprint (PDF and image)
- [ ] Upload expense receipt
- [ ] Verify existing notes/time entries still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)