### PR TITLE
feat: add Energi Electric brand tokens (colors + fonts)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,6 +10,18 @@
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
+
+  /* Energi Electric brand tokens.
+     Colors generate Tailwind utilities: bg-energi-primary, text-energi-primary, border-energi-primary, etc.
+     Fonts generate: font-heading, font-body, font-display-mono. */
+  --color-energi-primary: #045815;
+  --color-energi-primary-dark: #023510;
+  --color-energi-primary-light: #0a7a21;
+  --color-energi-white: #ffffff;
+
+  --font-heading: var(--font-barlow-condensed);
+  --font-body: var(--font-barlow);
+  --font-display-mono: var(--font-plex-mono);
 }
 
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,11 @@
 import type { Metadata, Viewport } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import {
+  Geist,
+  Geist_Mono,
+  Barlow_Condensed,
+  Barlow,
+  IBM_Plex_Mono,
+} from "next/font/google";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -10,6 +16,24 @@ const geistSans = Geist({
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
+});
+
+const barlowCondensed = Barlow_Condensed({
+  variable: "--font-barlow-condensed",
+  subsets: ["latin"],
+  weight: ["400", "600", "700"],
+});
+
+const barlow = Barlow({
+  variable: "--font-barlow",
+  subsets: ["latin"],
+  weight: ["300", "400", "500"],
+});
+
+const plexMono = IBM_Plex_Mono({
+  variable: "--font-plex-mono",
+  subsets: ["latin"],
+  weight: ["400", "500"],
 });
 
 export const metadata: Metadata = {
@@ -37,7 +61,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`light ${geistSans.variable} ${geistMono.variable} h-full antialiased`}
+      className={`light ${geistSans.variable} ${geistMono.variable} ${barlowCondensed.variable} ${barlow.variable} ${plexMono.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col">{children}</body>
     </html>


### PR DESCRIPTION
## Summary
Closes [BlueWaveCreative/Operations#2](https://github.com/BlueWaveCreative/Operations/issues/2).

Adds Energi Electric brand tokens (colors + fonts) to `globals.css` and `layout.tsx`. **No visible changes to any page yet** — tokens are just available for Milestone 1 issues that apply them per-page (#8–#11).

### Colors (now usable as Tailwind utilities)
- `bg-energi-primary` / `text-energi-primary` / `border-energi-primary` — `#045815` (dark forest green from the final logo)
- `bg-energi-primary-dark` — `#023510` (hover/active)
- `bg-energi-primary-light` — `#0a7a21` (accents)
- `bg-energi-white` — `#ffffff`

### Fonts (now usable as Tailwind utilities)
- `font-heading` — Barlow Condensed (400 / 600 / 700)
- `font-body` — Barlow (300 / 400 / 500)
- `font-display-mono` — IBM Plex Mono (400 / 500)

Geist fonts retained as fallback so nothing breaks.

## Test plan
- [x] `next build` compiles cleanly, all 16 static pages generated
- [x] TypeScript clean on changed files
- [ ] Vercel preview deploy renders identically to current production (no visible changes expected)
- [ ] Production deploy on merge succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
