### PR TITLE
feat: Energi Electric page metadata + PWA manifest + favicon

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,28 +1,33 @@
 {
-  "name": "Blue Shores PM",
-  "short_name": "Blue Shores",
-  "description": "Project management for Blue Shores Electric",
+  "name": "Energi Electric",
+  "short_name": "Energi",
+  "description": "Business management for Energi Electric",
   "start_url": "/dashboard",
   "display": "standalone",
-  "background_color": "#32373C",
-  "theme_color": "#68BD45",
+  "background_color": "#ffffff",
+  "theme_color": "#045815",
   "orientation": "any",
   "icons": [
     {
-      "src": "/icons/icon-192.png",
+      "src": "/brand/icon-192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "/icons/icon-512.png",
+      "src": "/brand/icon-512.png",
       "sizes": "512x512",
       "type": "image/png"
     },
     {
-      "src": "/icons/icon-maskable.png",
+      "src": "/brand/icon-maskable-512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "maskable"
+    },
+    {
+      "src": "/brand/apple-touch-icon.png",
+      "sizes": "180x180",
+      "type": "image/png"
     }
   ]
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -37,18 +37,31 @@ const plexMono = IBM_Plex_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Blue Shores PM",
-  description: "Project management for Blue Shores Electric",
+  title: "Energi Electric",
+  description: "Business management for Energi Electric",
   manifest: "/manifest.json",
+  icons: {
+    icon: [
+      { url: "/brand/favicon.ico", sizes: "any" },
+      { url: "/brand/icon-32.png", type: "image/png", sizes: "32x32" },
+      { url: "/brand/icon-192.png", type: "image/png", sizes: "192x192" },
+    ],
+    apple: { url: "/brand/apple-touch-icon.png", sizes: "180x180" },
+  },
   appleWebApp: {
     capable: true,
     statusBarStyle: "default",
-    title: "Blue Shores PM",
+    title: "Energi",
+  },
+  openGraph: {
+    title: "Energi Electric",
+    description: "Reliable protection. Safer homes.",
+    images: [{ url: "/brand/energi-logo-horizontal.png" }],
   },
 };
 
 export const viewport: Viewport = {
-  themeColor: "#68BD45",
+  themeColor: "#045815",
   width: "device-width",
   initialScale: 1,
 };


### PR DESCRIPTION
## Summary
Closes [BlueWaveCreative/Operations#5](https://github.com/BlueWaveCreative/Operations/issues/5).

Rebrands browser tab identity, iOS home-screen install, Android PWA, and social share previews from Blue Shores to Energi Electric.

### Changes

**`src/app/layout.tsx`** — Next.js metadata + viewport:
- `title`: `"Blue Shores PM"` → `"Energi Electric"`
- `description`: `"Project management for Blue Shores Electric"` → `"Business management for Energi Electric"`
- `appleWebApp.title`: `"Blue Shores PM"` → `"Energi"` (short — fits iOS home-screen under the icon)
- `themeColor`: `#68BD45` (Blue Shores green) → `#045815` (Energi forest green from final logo)
- Added `icons` (favicon.ico + icon-32 + icon-192 + apple-touch-icon)
- Added `openGraph` (title + tagline + horizontal logo as share image)

**`public/manifest.json`** — PWA manifest:
- `name`, `short_name`, `description` → Energi
- `theme_color`: `#045815` (Energi green)
- `background_color`: `#32373C` (dark gray) → `#ffffff` (clean white — better contrast with the dark green logo)
- Icons paths: `/icons/*` (empty folder) → `/brand/icon-*.png` (the real Energi icons staged earlier)
- Added `apple-touch-icon.png` (180×180 with solid Energi green bg for iOS)

### Not in this PR
- UI copy inside the app (help page, settings SMS body, sw.js push title, CSV filename) — Issue #12, separate PR.
- Per-page color tokens — Issues #9, #10, #11, still pending.

## Test plan
- [x] `next build` compiles cleanly
- [ ] Browser tab shows "Energi Electric" (page title)
- [ ] iPhone "Add to Home Screen" shows Energi icon + "Energi" label
- [ ] Android Chrome PWA install prompt works
- [ ] Social share preview (LinkedIn/Slack/iMessage paste) shows Energi logo + description

🤖 Generated with [Claude Code](https://claude.com/claude-code)
