### PR TITLE
feat: UI copy scrub + fix middleware intercepting /manifest.json and /sw.js

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,5 +1,5 @@
 self.addEventListener('push', function (event) {
-  var data = { title: 'Blue Shores PM', body: '' }
+  var data = { title: 'Energi Electric', body: '' }
   try {
     data = event.data.json()
   } catch (e) {
@@ -9,8 +9,8 @@ self.addEventListener('push', function (event) {
   event.waitUntil(
     self.registration.showNotification(data.title, {
       body: data.body,
-      icon: '/icons/icon-192.png',
-      badge: '/icons/icon-192.png',
+      icon: '/brand/icon-192.png',
+      badge: '/brand/icon-192.png',
     })
   )
 })

--- a/src/app/(authenticated)/help/page.tsx
+++ b/src/app/(authenticated)/help/page.tsx
@@ -53,12 +53,12 @@ export default async function HelpPage() {
 
   return (
     <div>
-      <PageHeader title="How to Use Blue Shores PM" />
+      <PageHeader title="How to Use Energi Electric" />
       <div className="p-4 md:p-6 max-w-3xl">
 
         <div className="mb-6">
           <p className="text-gray-600">
-            Blue Shores PM helps you track projects, log time, capture photos, and annotate blueprints.
+            Energi Electric helps you track projects, log time, capture photos, and annotate blueprints.
             {isAdmin ? ' As an admin, you can also manage templates, users, and view reports.' : ''}
           </p>
         </div>
@@ -330,7 +330,7 @@ export default async function HelpPage() {
         <h3 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3 mt-8">Tips</h3>
 
         <Section icon={Smartphone} title="Install as an App">
-          <p>On your phone, you can install Blue Shores PM as an app for quick access:</p>
+          <p>On your phone, you can install Energi Electric as an app for quick access:</p>
           <p><strong>iPhone:</strong> In Safari, tap the share button (square with arrow) → <strong>Add to Home Screen</strong>.</p>
           <p><strong>Android:</strong> In Chrome, tap the menu (three dots) → <strong>Add to Home Screen</strong>.</p>
           <p>The app works even with spotty signal — actions queue up and sync when you're back online.</p>

--- a/src/app/(authenticated)/settings/client.tsx
+++ b/src/app/(authenticated)/settings/client.tsx
@@ -31,7 +31,7 @@ function CustomerPortalRow({
   const [copying, setCopying] = useState(false)
   const [toggling, setToggling] = useState(false)
 
-  const baseUrl = typeof window !== 'undefined' ? window.location.origin : 'https://blue-shores-pm.vercel.app'
+  const baseUrl = typeof window !== 'undefined' ? window.location.origin : 'https://energi-electric-app.vercel.app'
   const portalUrl = `${baseUrl}/portal/${customer.portal_token}`
 
   async function handleToggle() {
@@ -48,7 +48,7 @@ function CustomerPortalRow({
   }
 
   const phone = customer.phone?.replace(/\D/g, '') ?? ''
-  const smsBody = encodeURIComponent(`Hi ${customer.name}, here's your Blue Shores Electric project portal: ${portalUrl}`)
+  const smsBody = encodeURIComponent(`Hi ${customer.name}, here's your Energi Electric project portal: ${portalUrl}`)
   const smsHref = phone ? `sms:${phone}?&body=${smsBody}` : null
 
   return (

--- a/src/components/reports/csv-export.tsx
+++ b/src/components/reports/csv-export.tsx
@@ -33,7 +33,7 @@ export function CSVExport({ entries }: CSVExportProps) {
 
     const csv = generateCSV(headers, rows)
     const date = new Date().toISOString().split('T')[0]
-    downloadCSV(csv, `blue-shores-time-report-${date}.csv`)
+    downloadCSV(csv, `energi-electric-time-report-${date}.csv`)
   }
 
   return (

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -7,6 +7,11 @@ export async function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
-    '/((?!_next/static|_next/image|favicon.ico|api/|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+    // Exclude Next.js internals, API routes, and common static assets
+    // (images, favicon, manifest.json, service worker, robots/sitemap).
+    // Without these exclusions, Supabase auth middleware intercepts
+    // /manifest.json and /sw.js and returns HTML instead of the expected
+    // JSON/JS — breaking PWA install + push notifications.
+    '/((?!_next|api/|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|json|js|txt|xml|webmanifest)$).*)',
   ],
 }


### PR DESCRIPTION
## Summary
Closes [BlueWaveCreative/Operations#12](https://github.com/BlueWaveCreative/Operations/issues/12).

Final UI copy scrub **plus** an incidental middleware bug fix discovered during Dispatch QA of the previous rebrand PR.

### Part 1 — Copy scrub (Issue #12)

Replaces remaining user-visible "Blue Shores" strings with "Energi Electric" per `docs/rebrand-inventory.md`.

- **`src/app/(authenticated)/help/page.tsx`** — 3 strings (title, intro, install-tip)
- **`src/app/(authenticated)/settings/client.tsx`** — 2 (customer SMS body + fallback URL)
- **`public/sw.js`** — 3 (push-notification title, icon path, badge path) — paths updated from the dead `/icons/` folder to `/brand/icon-192.png`
- **`src/components/reports/csv-export.tsx`** — CSV filename prefix

### Part 2 — Middleware fix

**Bug:** Supabase auth middleware was intercepting `/manifest.json` and `/sw.js` (and `robots.txt`, `sitemap.xml`, etc.) — these requests ended up at the login page HTML instead of the expected JSON/JS. Caught by Dispatch on PR #40.

**Effect on prod:** PWA install was silently broken (browser fetches `/manifest.json`, receives HTML, ignores it). Service worker registration also at risk.

**Fix:** Expanded the middleware `matcher` exclude list to cover `ico`, `json`, `js`, `txt`, `xml`, `webmanifest` extensions, and simplified `_next/static|_next/image` to just `_next` prefix.

### Intentionally NOT changed (inventory Bucket F)
- `R2_BUCKET = 'blue-shores'` — renaming the bucket invalidates existing photo URLs
- `TIMER_KEY = 'blue-shores-timer'` (localStorage) — renaming wipes active timers
- `DB_NAME = 'blue-shores-pm'` (IndexedDB) — renaming wipes offline cache

### Not in this PR
- Portal phone number `(910) 619-2000` — blocked on Joe's Energi contact info (Issue #6)
- Repo hygiene (`package.json`, `CLAUDE.md`) — Bucket E, optional separate cleanup

## Test plan
- [x] `next build` compiles cleanly
- [ ] `/manifest.json` returns **JSON** (not HTML) after deploy
- [ ] `/sw.js` returns **JavaScript** (not HTML)
- [ ] Help page shows "Energi Electric" in title + body
- [ ] CSV export filename starts with `energi-electric-`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
