### PR TITLE
chore: rename package + update CLAUDE.md to Energi Electric

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,13 @@
-# Blue Shores PM
+# Energi Electric App
 
 ## Project Context
-Custom project management app for Blue Shores Electric (Joe Lopez).
-- **Live:** https://blue-shores-pm.vercel.app
+Custom business management app for Energi Electric (Joe Lopez). Pivoted from the original Blue Shores PM build on 2026-04-24.
+- **Live:** https://energi-electric-app.vercel.app
 - **Stack:** Next.js 16 + Supabase + Cloudflare R2 + Vercel
 - **Supabase project:** jhznaijckdrokjpglwpp (us-east-1)
-- **R2 bucket:** blue-shores
+- **R2 bucket:** `blue-shores` (kept — renaming would invalidate every existing photo URL; see `docs/rebrand-inventory.md` Bucket F)
+- **PRD:** `docs/PRD.md`
+- **Brand:** Energi green `#045815`, Barlow Condensed (headings) + Barlow (body) + IBM Plex Mono (numbers). Tagline: "Reliable protection. Safer homes."
 
 ## Git Workflow
 - **Never push directly to main.** Always create a feature branch, push it, create a PR, and wait for Kenny's approval before merging.
@@ -20,8 +22,8 @@ Custom project management app for Blue Shores Electric (Joe Lopez).
 - All env vars must be set for both `production` AND `preview` environments
 
 ## Code Standards
-- Brand color: `#68BD45` (green) — no blue anywhere in the app
-- Dark sidebar/login: `#32373C`
+- Brand color: `#045815` (Energi forest green). Use Tailwind utility `bg-energi-primary` / `text-energi-primary` / `border-energi-primary` (defined in `globals.css`).
+- Legacy Blue Shores green `#68BD45` and dark sidebar `#32373C` still appear on some pages — being phased out in M1 issues #8, #9, #10, #11.
 - All text on light backgrounds must be `text-gray-500` minimum — never use `text-gray-300` or `text-gray-400` on white/gray-50 backgrounds
 - All headings must have explicit `text-gray-900`
 - All pages must have `export const dynamic = 'force-dynamic'` to prevent stale data

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "blue-shores-pm",
+  "name": "energi-electric-app",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "blue-shores-pm",
+      "name": "energi-electric-app",
       "version": "0.1.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1022.0",
@@ -4182,6 +4182,70 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "blue-shores-pm",
+  "name": "energi-electric-app",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
Repo hygiene — addresses Bucket E from `docs/rebrand-inventory.md`. No user-visible change.

### Changes
- **`package.json`** — `name` field: `"blue-shores-pm"` → `"energi-electric-app"`
- **`package-lock.json`** — regenerated to match
- **`CLAUDE.md`** — rewrote project context:
  - Title: "Blue Shores PM" → "Energi Electric App"
  - Live URL updated to `energi-electric-app.vercel.app`
  - Notes the project is a pivot from Blue Shores PM (dated 2026-04-24)
  - Documents the Energi brand: color `#045815`, fonts (Barlow Condensed / Barlow / IBM Plex Mono), tagline
  - References the PRD location
  - Explains why the R2 bucket name stays as `blue-shores` (Bucket F — renaming invalidates existing photo URLs)
  - Updated brand-color guidance from `#68BD45` to point to the new Tailwind utility `bg-energi-primary`

### Not in this PR
- Code changes — none. Build still passes (`next build` ✓).
- The R2 bucket name in code (`r2.ts`, scripts) — explicitly kept per Bucket F.
- localStorage / IndexedDB keys — explicitly kept per Bucket F.

## Test plan
- [x] `next build` compiles cleanly
- [ ] Vercel deploy succeeds (no behavior change expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
