### PR TITLE
feat: rebrand auth pages — white bg + Energi green accents

### DIFF
--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -30,7 +30,7 @@ export default function ForgotPasswordPage() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-[#32373C] px-4">
+    <div className="min-h-screen flex items-center justify-center bg-white px-4">
       <div className="w-full max-w-sm">
         <div className="flex justify-center mb-6">
           <img src="/brand/energi-logo-horizontal.png" alt="Energi Electric" className="h-12" />
@@ -38,29 +38,29 @@ export default function ForgotPasswordPage() {
 
         {sent ? (
           <div className="text-center">
-            <p className="text-white text-lg font-medium mb-2">Check your email</p>
-            <p className="text-gray-400 text-sm mb-6">
-              We sent a password reset link to <span className="text-white">{email}</span>
+            <p className="text-gray-900 text-lg font-medium mb-2">Check your email</p>
+            <p className="text-gray-600 text-sm mb-6">
+              We sent a password reset link to <span className="text-gray-900 font-medium">{email}</span>
             </p>
-            <Link href="/login" className="text-[#68BD45] text-sm hover:underline">
+            <Link href="/login" className="text-energi-primary text-sm hover:underline">
               Back to sign in
             </Link>
           </div>
         ) : (
           <>
-            <p className="text-gray-400 text-center mb-8">
+            <p className="text-gray-600 text-center mb-8">
               Enter your email and we&apos;ll send you a reset link
             </p>
 
             <form onSubmit={handleSubmit} className="space-y-4">
               {error && (
-                <div className="bg-red-900/30 text-red-400 border border-red-800/50 text-sm p-3 rounded-lg" role="alert">
+                <div className="bg-red-50 text-red-700 border border-red-200 text-sm p-3 rounded-lg" role="alert">
                   {error}
                 </div>
               )}
 
               <div>
-                <label htmlFor="email" className="block text-sm font-medium text-gray-300 mb-1">
+                <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
                   Email
                 </label>
                 <input
@@ -69,7 +69,7 @@ export default function ForgotPasswordPage() {
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   required
-                  className="w-full px-3 py-2 bg-white/10 border border-gray-600 text-white rounded-lg focus:ring-2 focus:ring-[#68BD45] focus:border-transparent placeholder:text-gray-500"
+                  className="w-full px-3 py-2 bg-white border border-gray-300 text-gray-900 rounded-lg focus:ring-2 focus:ring-energi-primary focus:border-energi-primary placeholder:text-gray-400"
                   placeholder="you@example.com"
                 />
               </div>
@@ -77,14 +77,14 @@ export default function ForgotPasswordPage() {
               <button
                 type="submit"
                 disabled={loading}
-                className="w-full py-2 px-4 bg-[#68BD45] text-white font-medium rounded-lg hover:bg-[#5aa83c] disabled:opacity-50 disabled:cursor-not-allowed"
+                className="w-full py-2 px-4 bg-energi-primary text-white font-medium rounded-lg hover:bg-energi-primary-dark disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {loading ? 'Sending...' : 'Send Reset Link'}
               </button>
             </form>
 
             <p className="text-center mt-4">
-              <Link href="/login" className="text-[#68BD45] text-sm hover:underline">
+              <Link href="/login" className="text-energi-primary text-sm hover:underline">
                 Back to sign in
               </Link>
             </p>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -58,13 +58,13 @@ function LoginForm() {
   return (
     <form onSubmit={handleLogin} className="space-y-4">
       {error && (
-        <div className="bg-red-900/30 text-red-400 border border-red-800/50 text-sm p-3 rounded-lg" role="alert">
+        <div className="bg-red-50 text-red-700 border border-red-200 text-sm p-3 rounded-lg" role="alert">
           {error}
         </div>
       )}
 
       <div>
-        <label htmlFor="email" className="block text-sm font-medium text-gray-300 mb-1">
+        <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
           Email
         </label>
         <input
@@ -73,13 +73,13 @@ function LoginForm() {
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           required
-          className="w-full px-3 py-2 bg-white/10 border border-gray-600 text-white rounded-lg focus:ring-2 focus:ring-[#68BD45] focus:border-transparent placeholder:text-gray-500"
+          className="w-full px-3 py-2 bg-white border border-gray-300 text-gray-900 rounded-lg focus:ring-2 focus:ring-energi-primary focus:border-energi-primary placeholder:text-gray-400"
           placeholder="you@example.com"
         />
       </div>
 
       <div>
-        <label htmlFor="password" className="block text-sm font-medium text-gray-300 mb-1">
+        <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-1">
           Password
         </label>
         <input
@@ -88,12 +88,12 @@ function LoginForm() {
           value={password}
           onChange={(e) => setPassword(e.target.value)}
           required
-          className="w-full px-3 py-2 bg-white/10 border border-gray-600 text-white rounded-lg focus:ring-2 focus:ring-[#68BD45] focus:border-transparent"
+          className="w-full px-3 py-2 bg-white border border-gray-300 text-gray-900 rounded-lg focus:ring-2 focus:ring-energi-primary focus:border-energi-primary"
         />
       </div>
 
       <div className="flex justify-end">
-        <Link href="/forgot-password" className="text-sm text-[#68BD45] hover:underline">
+        <Link href="/forgot-password" className="text-sm text-energi-primary hover:underline">
           Forgot password?
         </Link>
       </div>
@@ -101,7 +101,7 @@ function LoginForm() {
       <button
         type="submit"
         disabled={loading}
-        className="w-full py-2 px-4 bg-[#68BD45] text-white font-medium rounded-lg hover:bg-[#5aa83c] disabled:opacity-50 disabled:cursor-not-allowed"
+        className="w-full py-2 px-4 bg-energi-primary text-white font-medium rounded-lg hover:bg-energi-primary-dark disabled:opacity-50 disabled:cursor-not-allowed"
       >
         {loading ? 'Signing in...' : 'Sign In'}
       </button>
@@ -111,13 +111,13 @@ function LoginForm() {
 
 export default function LoginPage() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-[#32373C] px-4">
+    <div className="min-h-screen flex items-center justify-center bg-white px-4">
       <div className="w-full max-w-sm">
         <div className="flex justify-center mb-6">
           <img src="/brand/energi-logo-horizontal.png" alt="Energi Electric" className="h-12" />
         </div>
-        <p className="text-gray-400 text-center mb-8">Sign in to your account</p>
-        <Suspense fallback={<p className="text-gray-400 text-center">Loading...</p>}>
+        <p className="text-gray-600 text-center mb-8">Sign in to your account</p>
+        <Suspense fallback={<p className="text-gray-600 text-center">Loading...</p>}>
           <LoginForm />
         </Suspense>
       </div>

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -48,27 +48,27 @@ export default function ResetPasswordPage() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-[#32373C] px-4">
+    <div className="min-h-screen flex items-center justify-center bg-white px-4">
       <div className="w-full max-w-sm">
         <div className="flex justify-center mb-6">
           <img src="/brand/energi-logo-horizontal.png" alt="Energi Electric" className="h-12" />
         </div>
 
         {!ready ? (
-          <p className="text-gray-400 text-center">Verifying reset link...</p>
+          <p className="text-gray-600 text-center">Verifying reset link...</p>
         ) : (
           <>
-            <p className="text-gray-400 text-center mb-8">Set your new password</p>
+            <p className="text-gray-600 text-center mb-8">Set your new password</p>
 
             <form onSubmit={handleSubmit} className="space-y-4">
               {error && (
-                <div className="bg-red-900/30 text-red-400 border border-red-800/50 text-sm p-3 rounded-lg" role="alert">
+                <div className="bg-red-50 text-red-700 border border-red-200 text-sm p-3 rounded-lg" role="alert">
                   {error}
                 </div>
               )}
 
               <div>
-                <label htmlFor="password" className="block text-sm font-medium text-gray-300 mb-1">
+                <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-1">
                   New Password
                 </label>
                 <input
@@ -78,13 +78,13 @@ export default function ResetPasswordPage() {
                   onChange={(e) => setPassword(e.target.value)}
                   required
                   minLength={8}
-                  className="w-full px-3 py-2 bg-white/10 border border-gray-600 text-white rounded-lg focus:ring-2 focus:ring-[#68BD45] focus:border-transparent"
+                  className="w-full px-3 py-2 bg-white border border-gray-300 text-gray-900 rounded-lg focus:ring-2 focus:ring-energi-primary focus:border-energi-primary placeholder:text-gray-400"
                   placeholder="Min 8 characters"
                 />
               </div>
 
               <div>
-                <label htmlFor="confirm" className="block text-sm font-medium text-gray-300 mb-1">
+                <label htmlFor="confirm" className="block text-sm font-medium text-gray-700 mb-1">
                   Confirm Password
                 </label>
                 <input
@@ -94,14 +94,14 @@ export default function ResetPasswordPage() {
                   onChange={(e) => setConfirm(e.target.value)}
                   required
                   minLength={8}
-                  className="w-full px-3 py-2 bg-white/10 border border-gray-600 text-white rounded-lg focus:ring-2 focus:ring-[#68BD45] focus:border-transparent"
+                  className="w-full px-3 py-2 bg-white border border-gray-300 text-gray-900 rounded-lg focus:ring-2 focus:ring-energi-primary focus:border-energi-primary"
                 />
               </div>
 
               <button
                 type="submit"
                 disabled={loading}
-                className="w-full py-2 px-4 bg-[#68BD45] text-white font-medium rounded-lg hover:bg-[#5aa83c] disabled:opacity-50 disabled:cursor-not-allowed"
+                className="w-full py-2 px-4 bg-energi-primary text-white font-medium rounded-lg hover:bg-energi-primary-dark disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {loading ? 'Updating...' : 'Update Password'}
               </button>

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -4,11 +4,11 @@ function SignupContent() {
   // Signup is invite-only — admin creates accounts
   return (
     <div className="text-center">
-      <p className="text-white text-lg font-medium mb-2">Invite Required</p>
-      <p className="text-gray-400 text-sm mb-6">
+      <p className="text-gray-900 text-lg font-medium mb-2">Invite Required</p>
+      <p className="text-gray-600 text-sm mb-6">
         Contact your admin to get an account set up.
       </p>
-      <Link href="/login" className="text-[#68BD45] text-sm hover:underline">
+      <Link href="/login" className="text-energi-primary text-sm hover:underline">
         Back to sign in
       </Link>
     </div>
@@ -17,7 +17,7 @@ function SignupContent() {
 
 export default function SignupPage() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-[#32373C] px-4">
+    <div className="min-h-screen flex items-center justify-center bg-white px-4">
       <div className="w-full max-w-sm">
         <div className="flex justify-center mb-6">
           <img src="/brand/energi-logo-horizontal.png" alt="Energi Electric" className="h-12" />


### PR DESCRIPTION
## Summary

Rebrands the 4 auth pages (login, signup, forgot-password, reset-password) from Blue Shores dark-mode styling to a clean light theme with Energi green accents.

### Why
On the dark `#32373C` background, the Energi logo (green text on transparent) was barely readable — caught during the visual QA of the first rebrand wave. Also the Sign In button was still the bright Blue Shores green `#68BD45`, not Energi's `#045815`.

### Changes per page
- **Background:** `#32373C` → white
- **Labels:** `text-gray-300` → `text-gray-700`
- **Input fields:** transparent-over-dark → white with gray-300 border
- **Buttons:** `#68BD45` → `bg-energi-primary` (`#045815`)
- **Button hover:** `#5aa83c` → `bg-energi-primary-dark` (`#023510`)
- **Focus ring:** `#68BD45` → `energi-primary`
- **Forgot-password link:** `#68BD45` → `text-energi-primary`
- **Error banner:** dark-mode red → light-mode red

Logo now reads perfectly against white. Matches the rest of the app's light theme.

## Test plan
- [x] `next build` compiles cleanly
- [ ] Visually verify on login, signup, forgot-password, reset-password
- [ ] No regressions in auth flow (sign in, invite, password reset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
