### PR TITLE
feat(m3): materials + quotes schema, types, calc engine

### DIFF
--- a/src/lib/quotes/calc.ts
+++ b/src/lib/quotes/calc.ts
@@ -1,0 +1,65 @@
+import type { Quote, QuoteLineItem, QuoteTotals } from '@/lib/types/database'
+
+type QuoteSettings = Pick<
+  Quote,
+  | 'markup_enabled'
+  | 'markup_percent'
+  | 'tax_enabled'
+  | 'tax_percent'
+  | 'labor_rate'
+  | 'labor_hours'
+  | 'flat_fee_enabled'
+  | 'flat_fee'
+>
+
+type QuoteLineForCalc = Pick<QuoteLineItem, 'unit_price' | 'quantity'>
+
+const round2 = (n: number) => Math.round(n * 100) / 100
+
+/**
+ * Compute quote totals from line items + pricing knobs.
+ * Formula source: docs/joe-materials-prototype.tsx
+ *   materialsTotal       = sum(unit_price * quantity)
+ *   markupAmount         = materialsTotal * markup_percent / 100  (only if markup_enabled)
+ *   laborAmount          = labor_rate * labor_hours               (NOT marked up)
+ *   flatFeeAmount        = flat_fee                               (only if flat_fee_enabled)
+ *   subtotalBeforeTax    = materialsTotal + markupAmount + laborAmount + flatFeeAmount
+ *   taxAmount            = subtotalBeforeTax * tax_percent / 100  (only if tax_enabled)
+ *   grandTotal           = subtotalBeforeTax + taxAmount
+ */
+export function computeQuoteTotals(
+  lines: QuoteLineForCalc[],
+  settings: QuoteSettings,
+): QuoteTotals {
+  const materialsTotal = lines.reduce(
+    (sum, l) => sum + Number(l.unit_price) * Number(l.quantity),
+    0,
+  )
+
+  const markupAmount = settings.markup_enabled
+    ? materialsTotal * (Number(settings.markup_percent) / 100)
+    : 0
+
+  const laborAmount = Number(settings.labor_rate) * Number(settings.labor_hours)
+
+  const flatFeeAmount = settings.flat_fee_enabled ? Number(settings.flat_fee) : 0
+
+  const subtotalBeforeTax =
+    materialsTotal + markupAmount + laborAmount + flatFeeAmount
+
+  const taxAmount = settings.tax_enabled
+    ? subtotalBeforeTax * (Number(settings.tax_percent) / 100)
+    : 0
+
+  const grandTotal = subtotalBeforeTax + taxAmount
+
+  return {
+    materialsTotal: round2(materialsTotal),
+    markupAmount: round2(markupAmount),
+    laborAmount: round2(laborAmount),
+    flatFeeAmount: round2(flatFeeAmount),
+    subtotalBeforeTax: round2(subtotalBeforeTax),
+    taxAmount: round2(taxAmount),
+    grandTotal: round2(grandTotal),
+  }
+}

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -258,3 +258,108 @@ export interface InvoiceWithCustomer extends Invoice {
   customers: { name: string; email: string | null }
   projects: { name: string } | null
 }
+
+// =============================================================
+// Materials & Quotes (Milestone 3)
+// =============================================================
+
+export type MaterialUnit = 'ft' | 'ea' | 'box' | 'bag' | 'set'
+
+export interface MaterialCategory {
+  id: string
+  name: string
+  sort_order: number
+  created_at: string
+}
+
+export interface Material {
+  id: string
+  name: string
+  unit: MaterialUnit
+  price: number
+  category_id: string
+  sort_order: number
+  active: boolean
+  created_by: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface MaterialWithCategory extends Material {
+  material_categories: { name: string; sort_order: number }
+}
+
+export type QuoteStatus =
+  | 'draft'
+  | 'sent'
+  | 'accepted'
+  | 'declined'
+  | 'expired'
+  | 'converted'
+
+export type QuoteJobType = 'rough_in' | 'trim_out' | 'service'
+
+export interface Quote {
+  id: string
+  quote_number: number
+  customer_id: string
+  project_id: string | null
+  title: string
+  description: string
+  job_type: QuoteJobType
+  status: QuoteStatus
+  markup_enabled: boolean
+  markup_percent: number
+  tax_enabled: boolean
+  tax_percent: number
+  labor_rate: number
+  labor_hours: number
+  flat_fee_enabled: boolean
+  flat_fee: number
+  issued_date: string
+  valid_until: string | null
+  sent_at: string | null
+  converted_at: string | null
+  converted_to_invoice_id: string | null
+  notes: string | null
+  created_by: string
+  created_at: string
+  updated_at: string
+}
+
+export interface QuoteLineItem {
+  id: string
+  quote_id: string
+  material_id: string | null
+  material_name: string
+  unit: string
+  unit_price: number
+  quantity: number
+  phase: string
+  sort_order: number
+  created_at: string
+}
+
+export interface QuoteWithLineItems extends Quote {
+  quote_line_items: QuoteLineItem[]
+}
+
+export interface QuoteWithCustomer extends Quote {
+  customers: { name: string; email: string | null }
+  projects: { name: string } | null
+}
+
+/**
+ * Quote totals computed from line items + pricing knobs.
+ * Formula matches docs/joe-materials-prototype.tsx — labor is NOT marked up,
+ * tax is applied to materials + markup + labor + flat fee.
+ */
+export interface QuoteTotals {
+  materialsTotal: number
+  markupAmount: number
+  laborAmount: number
+  flatFeeAmount: number
+  subtotalBeforeTax: number
+  taxAmount: number
+  grandTotal: number
+}

--- a/supabase/migrations/010_materials_quotes.sql
+++ b/supabase/migrations/010_materials_quotes.sql
@@ -1,0 +1,245 @@
+-- Migration: 010_materials_quotes.sql
+-- Purpose: Materials database + Quotes (Milestone 3)
+-- PRD: docs/PRD.md §"Materials & Pricing Database (P0) — INTERNAL ONLY"
+-- Source data: docs/joe-materials-prototype.tsx
+
+-- ============================================================
+-- 1. Material categories ("phases" in Joe's prototype)
+-- ============================================================
+CREATE TABLE material_categories (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name        TEXT NOT NULL UNIQUE,
+  sort_order  INTEGER NOT NULL DEFAULT 0,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE material_categories ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Admins can manage categories"
+  ON material_categories FOR ALL
+  USING (get_user_role() = 'admin')
+  WITH CHECK (get_user_role() = 'admin');
+
+CREATE POLICY "Field workers can read categories"
+  ON material_categories FOR SELECT
+  USING (get_user_role() = 'field_worker');
+
+INSERT INTO material_categories (name, sort_order) VALUES
+  ('Rough-In',        1),
+  ('Trim-Out',        2),
+  ('Service/Panel',   3),
+  ('Temporary Power', 4),
+  ('Misc/Other',      5);
+
+-- ============================================================
+-- 2. Materials master
+-- ============================================================
+CREATE TABLE materials (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name         TEXT NOT NULL,
+  unit         TEXT NOT NULL CHECK (unit IN ('ft', 'ea', 'box', 'bag', 'set')),
+  price        NUMERIC(10,2) NOT NULL DEFAULT 0 CHECK (price >= 0),
+  category_id  UUID NOT NULL REFERENCES material_categories(id) ON DELETE RESTRICT,
+  sort_order   INTEGER NOT NULL DEFAULT 0,
+  active       BOOLEAN NOT NULL DEFAULT true,
+  created_by   UUID REFERENCES profiles(id),
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE materials ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Admins can manage materials"
+  ON materials FOR ALL
+  USING (get_user_role() = 'admin')
+  WITH CHECK (get_user_role() = 'admin');
+
+CREATE POLICY "Field workers can read materials"
+  ON materials FOR SELECT
+  USING (get_user_role() = 'field_worker');
+
+CREATE INDEX idx_materials_category ON materials(category_id);
+CREATE INDEX idx_materials_active   ON materials(active);
+
+-- Seed: 59 default materials from Joe's prototype.
+-- Sort order within each category preserves prototype ordering.
+DO $$
+DECLARE
+  cat_rough_in    UUID := (SELECT id FROM material_categories WHERE name = 'Rough-In');
+  cat_trim_out    UUID := (SELECT id FROM material_categories WHERE name = 'Trim-Out');
+  cat_service     UUID := (SELECT id FROM material_categories WHERE name = 'Service/Panel');
+  cat_temp_power  UUID := (SELECT id FROM material_categories WHERE name = 'Temporary Power');
+  cat_misc        UUID := (SELECT id FROM material_categories WHERE name = 'Misc/Other');
+BEGIN
+  -- Rough-In
+  INSERT INTO materials (name, unit, price, category_id, sort_order) VALUES
+    ('12/2 NM-B Wire',                'ft',  0.65, cat_rough_in,  1),
+    ('14/2 NM-B Wire',                'ft',  0.45, cat_rough_in,  2),
+    ('10/2 NM-B Wire',                'ft',  1.10, cat_rough_in,  3),
+    ('12/3 NM-B Wire',                'ft',  0.95, cat_rough_in,  4),
+    ('Single Gang Box (Plastic)',     'ea',  0.75, cat_rough_in,  5),
+    ('Double Gang Box (Plastic)',     'ea',  1.25, cat_rough_in,  6),
+    ('4" Square Box',                 'ea',  2.50, cat_rough_in,  7),
+    ('1/2" Romex Staples (box)',      'box', 4.50, cat_rough_in,  8),
+    ('1/2" EMT Conduit (10ft)',       'ea',  4.25, cat_rough_in,  9),
+    ('3/4" EMT Conduit (10ft)',       'ea',  6.50, cat_rough_in, 10),
+    ('1/2" EMT Connector',            'ea',  0.85, cat_rough_in, 11),
+    ('1/2" EMT Coupling',             'ea',  0.65, cat_rough_in, 12),
+    ('Low Voltage Bracket',           'ea',  1.20, cat_rough_in, 13),
+    ('Old Work Box',                  'ea',  2.10, cat_rough_in, 14);
+
+  -- Trim-Out
+  INSERT INTO materials (name, unit, price, category_id, sort_order) VALUES
+    ('15A Duplex Receptacle',         'ea',  1.85, cat_trim_out,  1),
+    ('20A Duplex Receptacle',         'ea',  3.25, cat_trim_out,  2),
+    ('GFCI Receptacle 15A',           'ea', 14.50, cat_trim_out,  3),
+    ('GFCI Receptacle 20A',           'ea', 17.00, cat_trim_out,  4),
+    ('AFCI Receptacle',               'ea', 28.00, cat_trim_out,  5),
+    ('Single Pole Switch 15A',        'ea',  2.50, cat_trim_out,  6),
+    ('3-Way Switch',                  'ea',  5.75, cat_trim_out,  7),
+    ('Dimmer Switch (Single Pole)',   'ea', 18.00, cat_trim_out,  8),
+    ('Decora Cover Plate',            'ea',  0.95, cat_trim_out,  9),
+    ('Standard Cover Plate',          'ea',  0.55, cat_trim_out, 10),
+    ('Smoke Detector (AC)',           'ea', 22.00, cat_trim_out, 11),
+    ('Combo Smoke/CO Detector',       'ea', 38.00, cat_trim_out, 12),
+    ('Wire Connector (bag/100)',      'bag', 8.50, cat_trim_out, 13);
+
+  -- Service/Panel
+  INSERT INTO materials (name, unit, price, category_id, sort_order) VALUES
+    ('200A Main Breaker Panel',       'ea', 185.00, cat_service,  1),
+    ('100A Main Breaker Panel',       'ea',  95.00, cat_service,  2),
+    ('Single Pole Breaker 15A',       'ea',   8.50, cat_service,  3),
+    ('Single Pole Breaker 20A',       'ea',   8.50, cat_service,  4),
+    ('Double Pole Breaker 30A',       'ea',  14.00, cat_service,  5),
+    ('Double Pole Breaker 50A',       'ea',  18.00, cat_service,  6),
+    ('AFCI Breaker 15A',              'ea',  42.00, cat_service,  7),
+    ('AFCI Breaker 20A',              'ea',  42.00, cat_service,  8),
+    ('GFCI Breaker 20A',              'ea',  48.00, cat_service,  9),
+    ('2/0 Aluminum Service Wire (ft)','ft',   2.85, cat_service, 10),
+    ('200A Meter Socket',             'ea',  68.00, cat_service, 11),
+    ('Ground Rod (8ft)',              'ea',  12.50, cat_service, 12),
+    ('Ground Rod Clamp',              'ea',   3.25, cat_service, 13),
+    ('2" PVC Conduit (10ft)',         'ea',   9.50, cat_service, 14),
+    ('2" PVC LB',                     'ea',   8.75, cat_service, 15);
+
+  -- Temporary Power
+  INSERT INTO materials (name, unit, price, category_id, sort_order) VALUES
+    ('Temp Power Pole',               'ea',  45.00, cat_temp_power, 1),
+    ('Spider Box (6-circuit)',        'ea', 185.00, cat_temp_power, 2),
+    ('50A Male Plug',                 'ea',  18.00, cat_temp_power, 3),
+    ('30A Receptacle',                'ea',  12.00, cat_temp_power, 4),
+    ('GFCI Inline Cord',              'ea',  22.00, cat_temp_power, 5),
+    ('10/3 SO Cord (ft)',             'ft',   2.10, cat_temp_power, 6),
+    ('Extension Cord 100ft 12g',      'ea',  38.00, cat_temp_power, 7);
+
+  -- Misc/Other
+  INSERT INTO materials (name, unit, price, category_id, sort_order) VALUES
+    ('Electrical Tape (roll)',        'ea',  1.85, cat_misc, 1),
+    ('Pull String (500ft)',           'ea', 12.00, cat_misc, 2),
+    ('Liquid Tight Connector 1/2"',   'ea',  2.25, cat_misc, 3),
+    ('Weatherproof Cover (1g)',       'ea',  4.50, cat_misc, 4),
+    ('Weatherproof Cover (2g)',       'ea',  6.75, cat_misc, 5),
+    ('Conduit Strap 1/2" (bag/10)',   'bag', 3.50, cat_misc, 6),
+    ('Knockouts (assorted)',          'set', 5.00, cat_misc, 7),
+    ('Anti-Short Bushings (bag)',     'bag', 2.75, cat_misc, 8),
+    ('Cable Ties (bag/100)',          'bag', 4.00, cat_misc, 9),
+    ('Label Tape',                    'ea',  8.50, cat_misc, 10);
+END $$;
+
+-- ============================================================
+-- 3. Quotes
+-- ============================================================
+CREATE SEQUENCE quote_number_seq START WITH 1001 INCREMENT BY 1;
+
+CREATE TABLE quotes (
+  id                       UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  quote_number             INTEGER NOT NULL UNIQUE DEFAULT nextval('quote_number_seq'),
+  customer_id              UUID NOT NULL REFERENCES customers(id) ON DELETE CASCADE,
+  project_id               UUID REFERENCES projects(id) ON DELETE SET NULL,
+  title                    TEXT NOT NULL,
+  -- Free-text description used as the customer-facing summary on the converted invoice:
+  -- "Provided material and labor for [description]"
+  description              TEXT NOT NULL DEFAULT '',
+  job_type                 TEXT NOT NULL CHECK (job_type IN ('rough_in', 'trim_out', 'service')),
+  status                   TEXT NOT NULL DEFAULT 'draft'
+                             CHECK (status IN ('draft', 'sent', 'accepted', 'declined', 'expired', 'converted')),
+  -- Pricing knobs (defaults match Joe's prototype)
+  markup_enabled           BOOLEAN NOT NULL DEFAULT true,
+  markup_percent           NUMERIC(5,2) NOT NULL DEFAULT 20.00 CHECK (markup_percent >= 0),
+  tax_enabled              BOOLEAN NOT NULL DEFAULT true,
+  tax_percent              NUMERIC(5,2) NOT NULL DEFAULT 8.50 CHECK (tax_percent >= 0),
+  labor_rate               NUMERIC(10,2) NOT NULL DEFAULT 85.00 CHECK (labor_rate >= 0),
+  labor_hours              NUMERIC(10,2) NOT NULL DEFAULT 0 CHECK (labor_hours >= 0),
+  flat_fee_enabled         BOOLEAN NOT NULL DEFAULT false,
+  flat_fee                 NUMERIC(10,2) NOT NULL DEFAULT 0 CHECK (flat_fee >= 0),
+  -- Lifecycle
+  issued_date              DATE NOT NULL DEFAULT CURRENT_DATE,
+  valid_until              DATE,
+  sent_at                  TIMESTAMPTZ,
+  converted_at             TIMESTAMPTZ,
+  converted_to_invoice_id  UUID REFERENCES invoices(id) ON DELETE SET NULL,
+  notes                    TEXT,
+  created_by               UUID NOT NULL REFERENCES profiles(id),
+  created_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at               TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE quotes ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Admins can manage quotes"
+  ON quotes FOR ALL
+  USING (get_user_role() = 'admin')
+  WITH CHECK (get_user_role() = 'admin');
+
+CREATE INDEX idx_quotes_customer ON quotes(customer_id);
+CREATE INDEX idx_quotes_project  ON quotes(project_id);
+CREATE INDEX idx_quotes_status   ON quotes(status);
+CREATE INDEX idx_quotes_invoice  ON quotes(converted_to_invoice_id);
+
+-- ============================================================
+-- 4. Quote line items (snapshotted from materials)
+-- ============================================================
+CREATE TABLE quote_line_items (
+  id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  quote_id       UUID NOT NULL REFERENCES quotes(id) ON DELETE CASCADE,
+  -- Nullable so deleting a material doesn't orphan history; snapshot fields remain authoritative.
+  material_id    UUID REFERENCES materials(id) ON DELETE SET NULL,
+  -- Snapshot fields — authoritative once written.
+  material_name  TEXT NOT NULL,
+  unit           TEXT NOT NULL,
+  unit_price     NUMERIC(10,2) NOT NULL CHECK (unit_price >= 0),
+  quantity       NUMERIC(10,2) NOT NULL DEFAULT 1 CHECK (quantity >= 0),
+  -- Phase snapshot (for grouping in UI / printout)
+  phase          TEXT NOT NULL,
+  sort_order     INTEGER NOT NULL DEFAULT 0,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE quote_line_items ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Admins can manage quote line items"
+  ON quote_line_items FOR ALL
+  USING (get_user_role() = 'admin')
+  WITH CHECK (get_user_role() = 'admin');
+
+CREATE INDEX idx_quote_lines_quote    ON quote_line_items(quote_id);
+CREATE INDEX idx_quote_lines_material ON quote_line_items(material_id);
+
+-- ============================================================
+-- 5. updated_at triggers
+-- ============================================================
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_materials_updated_at
+  BEFORE UPDATE ON materials
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER trg_quotes_updated_at
+  BEFORE UPDATE ON quotes
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();

--- a/tests/lib/quotes-calc.test.ts
+++ b/tests/lib/quotes-calc.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import { computeQuoteTotals } from '@/lib/quotes/calc'
+
+const baseSettings = {
+  markup_enabled: true,
+  markup_percent: 20,
+  tax_enabled: true,
+  tax_percent: 8.5,
+  labor_rate: 85,
+  labor_hours: 0,
+  flat_fee_enabled: false,
+  flat_fee: 0,
+}
+
+describe('computeQuoteTotals', () => {
+  it('returns zeros for empty quote', () => {
+    const t = computeQuoteTotals([], baseSettings)
+    expect(t.materialsTotal).toBe(0)
+    expect(t.grandTotal).toBe(0)
+  })
+
+  it('sums materials × quantities', () => {
+    const t = computeQuoteTotals(
+      [
+        { unit_price: 10, quantity: 3 },
+        { unit_price: 2.5, quantity: 4 },
+      ],
+      { ...baseSettings, markup_enabled: false, tax_enabled: false },
+    )
+    expect(t.materialsTotal).toBe(40)
+    expect(t.markupAmount).toBe(0)
+    expect(t.taxAmount).toBe(0)
+    expect(t.grandTotal).toBe(40)
+  })
+
+  it('applies markup to materials only, not labor', () => {
+    const t = computeQuoteTotals(
+      [{ unit_price: 100, quantity: 1 }],
+      { ...baseSettings, labor_hours: 1, tax_enabled: false },
+    )
+    // materials 100 + markup 20 + labor 85 = 205
+    expect(t.materialsTotal).toBe(100)
+    expect(t.markupAmount).toBe(20)
+    expect(t.laborAmount).toBe(85)
+    expect(t.subtotalBeforeTax).toBe(205)
+    expect(t.grandTotal).toBe(205)
+  })
+
+  it('applies tax to everything (materials + markup + labor + flat fee)', () => {
+    const t = computeQuoteTotals(
+      [{ unit_price: 100, quantity: 1 }],
+      {
+        ...baseSettings,
+        labor_hours: 1,
+        flat_fee_enabled: true,
+        flat_fee: 50,
+      },
+    )
+    // materials 100 + markup 20 + labor 85 + flat 50 = 255 subtotal
+    // tax = 255 * 0.085 = 21.675 → 21.68
+    // grand = 255 + 21.68 = 276.68
+    expect(t.subtotalBeforeTax).toBe(255)
+    expect(t.taxAmount).toBe(21.68)
+    expect(t.grandTotal).toBe(276.68)
+  })
+
+  it('skips markup when disabled', () => {
+    const t = computeQuoteTotals(
+      [{ unit_price: 100, quantity: 1 }],
+      { ...baseSettings, markup_enabled: false, tax_enabled: false },
+    )
+    expect(t.markupAmount).toBe(0)
+    expect(t.grandTotal).toBe(100)
+  })
+
+  it('skips flat fee when disabled', () => {
+    const t = computeQuoteTotals(
+      [],
+      {
+        ...baseSettings,
+        markup_enabled: false,
+        tax_enabled: false,
+        flat_fee_enabled: false,
+        flat_fee: 75,
+      },
+    )
+    expect(t.flatFeeAmount).toBe(0)
+    expect(t.grandTotal).toBe(0)
+  })
+
+  it('handles string-coerced numeric inputs (Postgres NUMERIC)', () => {
+    const t = computeQuoteTotals(
+      [{ unit_price: '12.50' as unknown as number, quantity: '4' as unknown as number }],
+      { ...baseSettings, markup_enabled: false, tax_enabled: false },
+    )
+    expect(t.materialsTotal).toBe(50)
+  })
+})


### PR DESCRIPTION
## Summary

First slice of Milestone 3 (Materials Database & Quotes). Schema + types + pure calc utility — no UI yet.

- **Migration `010_materials_quotes.sql`** — `material_categories` (5 phases), `materials` master + 59 seed items from Joe's prototype, `quotes` header (markup/tax/labor/flat-fee knobs + 6-state lifecycle), `quote_line_items` with full snapshot fields so historical quotes survive material edits/deletes. RLS: admins manage; field workers read materials/categories only; quotes admin-only.
- **TypeScript types** — `Material`, `MaterialCategory`, `Quote`, `QuoteLineItem` + joined types and `QuoteTotals`.
- **`computeQuoteTotals()`** — pure function matching `docs/joe-materials-prototype.tsx` exactly: labor exempt from markup, tax applied to materials + markup + labor + flat fee.
- **7 tests, all passing.**

## Issues

- Closes BlueWaveCreative/Operations#27 — materials schema
- Closes BlueWaveCreative/Operations#28 — quotes + line items schema
- Closes BlueWaveCreative/Operations#29 — seed 59 materials
- Refs BlueWaveCreative/Operations#34 — calc engine landed; totals **display** comes with the UI slice

## Test plan

- [x] `npx vitest run tests/lib/quotes-calc.test.ts` — 7/7 pass
- [x] `npx tsc --noEmit` clean (after removing Finder dupes from `.next/types/`)
- [x] Vercel preview build succeeds (Dispatch verified)
- [ ] **Post-merge: apply migration `010_materials_quotes.sql` to Supabase** (manual step — same pattern as 009)

## Next slices

1. Materials admin CRUD page (#30) + CSV import/export (#36, #37)
2. Quote builder UI (#31, #32, #33) wired to `computeQuoteTotals()`
3. Quote → Invoice conversion (#38) + quotes list (#39)

🤖 Generated with [Claude Code](https://claude.com/claude-code)