### PR TITLE
feat(m3): materials admin page — list, search, CRUD

### DIFF
--- a/src/app/(authenticated)/materials/client.tsx
+++ b/src/app/(authenticated)/materials/client.tsx
@@ -1,0 +1,412 @@
+'use client'
+
+import { useState, useMemo } from 'react'
+import { useRouter } from 'next/navigation'
+import { Card } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Modal } from '@/components/ui/modal'
+import { Plus, Pencil, Trash2, Search, AlertCircle } from 'lucide-react'
+import type { Material, MaterialCategory, MaterialUnit } from '@/lib/types/database'
+
+const UNIT_OPTIONS: MaterialUnit[] = ['ft', 'ea', 'box', 'bag', 'set']
+
+interface MaterialsClientProps {
+  categories: MaterialCategory[]
+  materials: Material[]
+}
+
+interface MaterialFormState {
+  id?: string
+  name: string
+  unit: MaterialUnit
+  price: string
+  category_id: string
+}
+
+const blankForm = (categoryId: string): MaterialFormState => ({
+  name: '',
+  unit: 'ea',
+  price: '',
+  category_id: categoryId,
+})
+
+function formatCurrency(amount: number) {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+  }).format(amount)
+}
+
+const ICON_BUTTON_BASE =
+  'inline-flex items-center justify-center w-11 h-11 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-[#68BD45]'
+
+export function MaterialsClient({ categories, materials }: MaterialsClientProps) {
+  const router = useRouter()
+  const [search, setSearch] = useState('')
+
+  const [formOpen, setFormOpen] = useState(false)
+  const [form, setForm] = useState<MaterialFormState | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+  const [formError, setFormError] = useState<string | null>(null)
+
+  const [deleteTarget, setDeleteTarget] = useState<Material | null>(null)
+  const [deleting, setDeleting] = useState(false)
+
+  const [pageError, setPageError] = useState<string | null>(null)
+
+  const filtered = useMemo(() => {
+    if (!search.trim()) return materials
+    const q = search.toLowerCase()
+    return materials.filter((m) => m.name.toLowerCase().includes(q))
+  }, [materials, search])
+
+  const grouped = useMemo(() => {
+    const map = new Map<string, Material[]>()
+    for (const cat of categories) map.set(cat.id, [])
+    for (const m of filtered) {
+      const list = map.get(m.category_id)
+      if (list) list.push(m)
+    }
+    return map
+  }, [categories, filtered])
+
+  const noSearchMatches = search.trim().length > 0 && filtered.length === 0
+
+  function openNew(categoryId: string) {
+    setForm(blankForm(categoryId))
+    setFormError(null)
+    setFormOpen(true)
+  }
+
+  function openEdit(material: Material) {
+    setForm({
+      id: material.id,
+      name: material.name,
+      unit: material.unit,
+      price: material.price.toString(),
+      category_id: material.category_id,
+    })
+    setFormError(null)
+    setFormOpen(true)
+  }
+
+  function closeForm() {
+    setFormOpen(false)
+    setForm(null)
+    setFormError(null)
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!form) return
+    if (!form.name.trim()) {
+      setFormError('Name is required.')
+      return
+    }
+    const priceNum = Number(form.price)
+    if (Number.isNaN(priceNum) || priceNum < 0) {
+      setFormError('Price must be 0 or greater.')
+      return
+    }
+
+    setSubmitting(true)
+    setFormError(null)
+
+    const payload = {
+      name: form.name.trim(),
+      unit: form.unit,
+      price: priceNum,
+      category_id: form.category_id,
+    }
+
+    const url = form.id ? `/api/materials/${form.id}` : '/api/materials'
+    const method = form.id ? 'PATCH' : 'POST'
+
+    try {
+      const res = await fetch(url, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error(data.error ?? 'Save failed.')
+      }
+      closeForm()
+      router.refresh()
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : 'Save failed.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  async function confirmDelete() {
+    if (!deleteTarget) return
+    setDeleting(true)
+    setPageError(null)
+    try {
+      const res = await fetch(`/api/materials/${deleteTarget.id}`, {
+        method: 'DELETE',
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error(data.error ?? 'Delete failed.')
+      }
+      setDeleteTarget(null)
+      router.refresh()
+    } catch (err) {
+      setPageError(err instanceof Error ? err.message : 'Delete failed.')
+      setDeleteTarget(null)
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  if (categories.length === 0) {
+    return (
+      <Card>
+        <p className="text-sm text-gray-600 text-center py-8">
+          No material categories configured. Run migration{' '}
+          <code className="font-mono text-xs bg-gray-100 px-1 py-0.5 rounded">
+            010_materials_quotes.sql
+          </code>{' '}
+          to seed the defaults.
+        </p>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="space-y-6 max-w-5xl">
+      {pageError && (
+        <div
+          role="alert"
+          className="flex items-start gap-2 px-3 py-2 rounded-lg bg-red-50 border border-red-200 text-sm text-red-700"
+        >
+          <AlertCircle className="w-4 h-4 mt-0.5 shrink-0" />
+          <span className="flex-1">{pageError}</span>
+          <button
+            onClick={() => setPageError(null)}
+            className="text-red-500 hover:text-red-700 text-xs font-medium"
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
+
+      <div className="flex items-center gap-3 flex-wrap">
+        <div className="relative flex-1 min-w-[200px] max-w-sm">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
+          <input
+            type="search"
+            placeholder="Search materials…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            aria-label="Search materials"
+            className="w-full pl-9 pr-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#68BD45] focus:border-transparent text-sm"
+          />
+        </div>
+        <p className="text-sm text-gray-500" aria-live="polite">
+          {filtered.length} of {materials.length}
+        </p>
+      </div>
+
+      {noSearchMatches && (
+        <Card>
+          <p className="text-sm text-gray-600 text-center py-4">
+            No materials match &ldquo;{search}&rdquo;.
+          </p>
+        </Card>
+      )}
+
+      <div className="space-y-6">
+        {categories.map((cat) => {
+          const items = grouped.get(cat.id) ?? []
+          // Hide empty categories during a search to reduce noise.
+          if (search.trim() && items.length === 0) return null
+          return (
+            <Card key={cat.id} className="p-0 overflow-hidden">
+              <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200 bg-gray-50">
+                <div>
+                  <h2 className="text-base font-semibold text-gray-900">{cat.name}</h2>
+                  <p className="text-xs text-gray-500">
+                    {items.length} {items.length === 1 ? 'material' : 'materials'}
+                  </p>
+                </div>
+                <Button size="sm" variant="secondary" onClick={() => openNew(cat.id)}>
+                  <Plus className="w-4 h-4 mr-1" /> Add
+                </Button>
+              </div>
+
+              {items.length === 0 ? (
+                <p className="text-sm text-gray-500 px-4 py-6 text-center">
+                  No materials yet.
+                </p>
+              ) : (
+                <ul className="divide-y divide-gray-100">
+                  {items.map((m) => (
+                    <li
+                      key={m.id}
+                      className="flex items-center gap-2 sm:gap-3 px-3 sm:px-4 py-2.5 hover:bg-gray-50"
+                    >
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm font-medium text-gray-900 truncate">
+                          {m.name}
+                        </p>
+                        <p className="text-xs text-gray-500">per {m.unit}</p>
+                      </div>
+                      <p className="text-sm font-semibold text-gray-900 tabular-nums w-24 text-right shrink-0">
+                        {formatCurrency(m.price)}
+                      </p>
+                      <div className="flex items-center gap-1 shrink-0">
+                        <button
+                          type="button"
+                          onClick={() => openEdit(m)}
+                          className={`${ICON_BUTTON_BASE} text-gray-500 hover:bg-gray-200 hover:text-gray-700`}
+                          aria-label={`Edit ${m.name}`}
+                        >
+                          <Pencil className="w-4 h-4" />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => setDeleteTarget(m)}
+                          className={`${ICON_BUTTON_BASE} text-gray-500 hover:bg-red-50 hover:text-red-600`}
+                          aria-label={`Delete ${m.name}`}
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </button>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </Card>
+          )
+        })}
+      </div>
+
+      <Modal
+        open={formOpen}
+        onClose={closeForm}
+        title={form?.id ? 'Edit material' : 'New material'}
+      >
+        {form && (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <Input
+              id="material-name"
+              label="Name"
+              value={form.name}
+              onChange={(e) => setForm({ ...form, name: e.target.value })}
+              autoFocus
+              required
+            />
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label
+                  htmlFor="material-unit"
+                  className="block text-sm font-medium text-gray-700 mb-1"
+                >
+                  Unit
+                </label>
+                <select
+                  id="material-unit"
+                  value={form.unit}
+                  onChange={(e) =>
+                    setForm({ ...form, unit: e.target.value as MaterialUnit })
+                  }
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#68BD45] focus:border-transparent text-sm"
+                >
+                  {UNIT_OPTIONS.map((u) => (
+                    <option key={u} value={u}>
+                      {u}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <Input
+                id="material-price"
+                label="Price (USD)"
+                type="number"
+                step="0.01"
+                min="0"
+                value={form.price}
+                onChange={(e) => setForm({ ...form, price: e.target.value })}
+                required
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="material-category"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                Category
+              </label>
+              <select
+                id="material-category"
+                value={form.category_id}
+                onChange={(e) =>
+                  setForm({ ...form, category_id: e.target.value })
+                }
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#68BD45] focus:border-transparent text-sm"
+              >
+                {categories.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            {formError && (
+              <p role="alert" className="text-sm text-red-600">
+                {formError}
+              </p>
+            )}
+            <div className="flex justify-end gap-2 pt-2">
+              <Button type="button" variant="secondary" onClick={closeForm}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={submitting}>
+                {submitting ? 'Saving…' : 'Save'}
+              </Button>
+            </div>
+          </form>
+        )}
+      </Modal>
+
+      <Modal
+        open={deleteTarget !== null}
+        onClose={() => !deleting && setDeleteTarget(null)}
+        title="Delete material?"
+      >
+        {deleteTarget && (
+          <div className="space-y-4">
+            <p className="text-sm text-gray-700">
+              Remove <span className="font-semibold">{deleteTarget.name}</span> from your
+              materials list? Existing quotes that used this item are unaffected.
+            </p>
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={() => setDeleteTarget(null)}
+                disabled={deleting}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                variant="danger"
+                onClick={confirmDelete}
+                disabled={deleting}
+              >
+                {deleting ? 'Deleting…' : 'Delete'}
+              </Button>
+            </div>
+          </div>
+        )}
+      </Modal>
+    </div>
+  )
+}

--- a/src/app/(authenticated)/materials/client.tsx
+++ b/src/app/(authenticated)/materials/client.tsx
@@ -289,7 +289,7 @@ export function MaterialsClient({ categories, materials }: MaterialsClientProps)
 
       <Modal
         open={formOpen}
-        onClose={closeForm}
+        onClose={() => !submitting && closeForm()}
         title={form?.id ? 'Edit material' : 'New material'}
       >
         {form && (

--- a/src/app/(authenticated)/materials/page.tsx
+++ b/src/app/(authenticated)/materials/page.tsx
@@ -1,0 +1,45 @@
+export const dynamic = 'force-dynamic'
+
+import { redirect } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
+import { PageHeader } from '@/components/layout/page-header'
+import { MaterialsClient } from './client'
+import type { Material, MaterialCategory } from '@/lib/types/database'
+
+export default async function MaterialsPage() {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) redirect('/login')
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single()
+
+  if (profile?.role !== 'admin') redirect('/dashboard')
+
+  const [{ data: categories }, { data: materials }] = await Promise.all([
+    supabase
+      .from('material_categories')
+      .select('*')
+      .order('sort_order', { ascending: true }),
+    supabase
+      .from('materials')
+      .select('*')
+      .eq('active', true)
+      .order('sort_order', { ascending: true }),
+  ])
+
+  return (
+    <div>
+      <PageHeader title="Materials" />
+      <div className="p-4 md:p-6">
+        <MaterialsClient
+          categories={(categories ?? []) as MaterialCategory[]}
+          materials={(materials ?? []) as Material[]}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/app/api/materials/[id]/route.ts
+++ b/src/app/api/materials/[id]/route.ts
@@ -1,0 +1,115 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+
+const VALID_UNITS = ['ft', 'ea', 'box', 'bag', 'set'] as const
+
+async function requireAdmin() {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return { error: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single()
+  if (profile?.role !== 'admin') {
+    return { error: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) }
+  }
+  return { supabase }
+}
+
+export async function PATCH(
+  request: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id } = await context.params
+  const auth = await requireAdmin()
+  if ('error' in auth) return auth.error
+  const { supabase } = auth
+
+  const body = await request.json().catch(() => null)
+  if (!body || typeof body !== 'object') {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+  const { name, unit, price, category_id } = body as Record<string, unknown>
+
+  const updates: Record<string, unknown> = {}
+
+  if (name !== undefined) {
+    if (typeof name !== 'string' || !name.trim()) {
+      return NextResponse.json({ error: 'Name must be non-empty' }, { status: 400 })
+    }
+    updates.name = name.trim()
+  }
+  if (unit !== undefined) {
+    if (
+      typeof unit !== 'string' ||
+      !VALID_UNITS.includes(unit as (typeof VALID_UNITS)[number])
+    ) {
+      return NextResponse.json(
+        { error: `Unit must be one of ${VALID_UNITS.join(', ')}` },
+        { status: 400 },
+      )
+    }
+    updates.unit = unit
+  }
+  if (price !== undefined) {
+    const priceNum = Number(price)
+    if (!Number.isFinite(priceNum) || priceNum < 0) {
+      return NextResponse.json({ error: 'Price must be a number ≥ 0' }, { status: 400 })
+    }
+    updates.price = priceNum
+  }
+  if (category_id !== undefined) {
+    if (typeof category_id !== 'string' || !category_id) {
+      return NextResponse.json({ error: 'category_id must be non-empty' }, { status: 400 })
+    }
+    updates.category_id = category_id
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json({ error: 'No fields to update' }, { status: 400 })
+  }
+
+  const { data, error } = await supabase
+    .from('materials')
+    .update(updates)
+    .eq('id', id)
+    .select()
+    .single()
+
+  if (error || !data) {
+    return NextResponse.json(
+      { error: error?.message ?? 'Failed to update material' },
+      { status: 500 },
+    )
+  }
+
+  return NextResponse.json({ material: data })
+}
+
+export async function DELETE(
+  _request: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id } = await context.params
+  const auth = await requireAdmin()
+  if ('error' in auth) return auth.error
+  const { supabase } = auth
+
+  // Soft delete — preserves snapshots on existing quote line items.
+  const { error } = await supabase
+    .from('materials')
+    .update({ active: false })
+    .eq('id', id)
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  return NextResponse.json({ ok: true })
+}

--- a/src/app/api/materials/[id]/route.ts
+++ b/src/app/api/materials/[id]/route.ts
@@ -1,25 +1,19 @@
 import { NextResponse } from 'next/server'
-import { createClient } from '@/lib/supabase/server'
+import { requireAdmin } from '@/lib/api/admin'
 
 const VALID_UNITS = ['ft', 'ea', 'box', 'bag', 'set'] as const
 
-async function requireAdmin() {
-  const supabase = await createClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-  if (!user) {
-    return { error: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+function parsePrice(raw: unknown): number | null {
+  if (typeof raw === 'number') {
+    return Number.isFinite(raw) && raw >= 0 ? raw : null
   }
-  const { data: profile } = await supabase
-    .from('profiles')
-    .select('role')
-    .eq('id', user.id)
-    .single()
-  if (profile?.role !== 'admin') {
-    return { error: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) }
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim()
+    if (!trimmed) return null
+    const n = Number(trimmed)
+    return Number.isFinite(n) && n >= 0 ? n : null
   }
-  return { supabase }
+  return null
 }
 
 export async function PATCH(
@@ -27,6 +21,10 @@ export async function PATCH(
   context: { params: Promise<{ id: string }> },
 ) {
   const { id } = await context.params
+  if (!id) {
+    return NextResponse.json({ error: 'Missing id' }, { status: 400 })
+  }
+
   const auth = await requireAdmin()
   if ('error' in auth) return auth.error
   const { supabase } = auth
@@ -58,8 +56,8 @@ export async function PATCH(
     updates.unit = unit
   }
   if (price !== undefined) {
-    const priceNum = Number(price)
-    if (!Number.isFinite(priceNum) || priceNum < 0) {
+    const priceNum = parsePrice(price)
+    if (priceNum === null) {
       return NextResponse.json({ error: 'Price must be a number ≥ 0' }, { status: 400 })
     }
     updates.price = priceNum
@@ -82,11 +80,15 @@ export async function PATCH(
     .select()
     .single()
 
-  if (error || !data) {
-    return NextResponse.json(
-      { error: error?.message ?? 'Failed to update material' },
-      { status: 500 },
-    )
+  if (error) {
+    // PostgREST returns PGRST116 when .single() finds zero rows.
+    if (error.code === 'PGRST116') {
+      return NextResponse.json({ error: 'Material not found' }, { status: 404 })
+    }
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  if (!data) {
+    return NextResponse.json({ error: 'Material not found' }, { status: 404 })
   }
 
   return NextResponse.json({ material: data })
@@ -97,18 +99,31 @@ export async function DELETE(
   context: { params: Promise<{ id: string }> },
 ) {
   const { id } = await context.params
+  if (!id) {
+    return NextResponse.json({ error: 'Missing id' }, { status: 400 })
+  }
+
   const auth = await requireAdmin()
   if ('error' in auth) return auth.error
   const { supabase } = auth
 
   // Soft delete — preserves snapshots on existing quote line items.
-  const { error } = await supabase
+  // Use .select().single() so an unknown id returns 404 instead of silent 200.
+  const { data, error } = await supabase
     .from('materials')
     .update({ active: false })
     .eq('id', id)
+    .select('id')
+    .single()
 
   if (error) {
+    if (error.code === 'PGRST116') {
+      return NextResponse.json({ error: 'Material not found' }, { status: 404 })
+    }
     return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  if (!data) {
+    return NextResponse.json({ error: 'Material not found' }, { status: 404 })
   }
 
   return NextResponse.json({ ok: true })

--- a/src/app/api/materials/route.ts
+++ b/src/app/api/materials/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+
+const VALID_UNITS = ['ft', 'ea', 'box', 'bag', 'set'] as const
+
+export async function POST(request: Request) {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single()
+  if (profile?.role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const body = await request.json().catch(() => null)
+  if (!body) {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+  const { name, unit, price, category_id } = body as Record<string, unknown>
+
+  if (typeof name !== 'string' || !name.trim()) {
+    return NextResponse.json({ error: 'Name is required' }, { status: 400 })
+  }
+  if (typeof unit !== 'string' || !VALID_UNITS.includes(unit as (typeof VALID_UNITS)[number])) {
+    return NextResponse.json(
+      { error: `Unit must be one of ${VALID_UNITS.join(', ')}` },
+      { status: 400 },
+    )
+  }
+  const priceNum = Number(price)
+  if (!Number.isFinite(priceNum) || priceNum < 0) {
+    return NextResponse.json({ error: 'Price must be a number ≥ 0' }, { status: 400 })
+  }
+  if (typeof category_id !== 'string' || !category_id) {
+    return NextResponse.json({ error: 'category_id is required' }, { status: 400 })
+  }
+
+  const { data, error } = await supabase
+    .from('materials')
+    .insert({
+      name: name.trim(),
+      unit,
+      price: priceNum,
+      category_id,
+      created_by: user.id,
+    })
+    .select()
+    .single()
+
+  if (error || !data) {
+    return NextResponse.json(
+      { error: error?.message ?? 'Failed to create material' },
+      { status: 500 },
+    )
+  }
+
+  return NextResponse.json({ material: data }, { status: 201 })
+}

--- a/src/app/api/materials/route.ts
+++ b/src/app/api/materials/route.ts
@@ -1,25 +1,25 @@
 import { NextResponse } from 'next/server'
-import { createClient } from '@/lib/supabase/server'
+import { requireAdmin } from '@/lib/api/admin'
 
 const VALID_UNITS = ['ft', 'ea', 'box', 'bag', 'set'] as const
 
-export async function POST(request: Request) {
-  const supabase = await createClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-  if (!user) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+function parsePrice(raw: unknown): number | null {
+  if (typeof raw === 'number') {
+    return Number.isFinite(raw) && raw >= 0 ? raw : null
   }
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim()
+    if (!trimmed) return null
+    const n = Number(trimmed)
+    return Number.isFinite(n) && n >= 0 ? n : null
+  }
+  return null
+}
 
-  const { data: profile } = await supabase
-    .from('profiles')
-    .select('role')
-    .eq('id', user.id)
-    .single()
-  if (profile?.role !== 'admin') {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-  }
+export async function POST(request: Request) {
+  const auth = await requireAdmin()
+  if ('error' in auth) return auth.error
+  const { supabase, userId } = auth
 
   const body = await request.json().catch(() => null)
   if (!body) {
@@ -30,28 +30,60 @@ export async function POST(request: Request) {
   if (typeof name !== 'string' || !name.trim()) {
     return NextResponse.json({ error: 'Name is required' }, { status: 400 })
   }
-  if (typeof unit !== 'string' || !VALID_UNITS.includes(unit as (typeof VALID_UNITS)[number])) {
+  if (
+    typeof unit !== 'string' ||
+    !VALID_UNITS.includes(unit as (typeof VALID_UNITS)[number])
+  ) {
     return NextResponse.json(
       { error: `Unit must be one of ${VALID_UNITS.join(', ')}` },
       { status: 400 },
     )
   }
-  const priceNum = Number(price)
-  if (!Number.isFinite(priceNum) || priceNum < 0) {
+  const priceNum = parsePrice(price)
+  if (priceNum === null) {
     return NextResponse.json({ error: 'Price must be a number ≥ 0' }, { status: 400 })
   }
   if (typeof category_id !== 'string' || !category_id) {
     return NextResponse.json({ error: 'category_id is required' }, { status: 400 })
   }
 
+  const trimmedName = name.trim()
+
+  // If a soft-deleted material with the same name + category exists, reactivate
+  // it instead of creating a duplicate row. Quote line items snapshot their
+  // material data, so reactivation is safe.
+  const { data: existing } = await supabase
+    .from('materials')
+    .select('id')
+    .eq('name', trimmedName)
+    .eq('category_id', category_id)
+    .eq('active', false)
+    .maybeSingle()
+
+  if (existing) {
+    const { data, error } = await supabase
+      .from('materials')
+      .update({ active: true, unit, price: priceNum })
+      .eq('id', existing.id)
+      .select()
+      .single()
+    if (error || !data) {
+      return NextResponse.json(
+        { error: error?.message ?? 'Failed to reactivate material' },
+        { status: 500 },
+      )
+    }
+    return NextResponse.json({ material: data, reactivated: true })
+  }
+
   const { data, error } = await supabase
     .from('materials')
     .insert({
-      name: name.trim(),
+      name: trimmedName,
       unit,
       price: priceNum,
       category_id,
-      created_by: user.id,
+      created_by: userId,
     })
     .select()
     .single()

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
-import { LayoutDashboard, FolderOpen, FileStack, Settings, Clock, BarChart3, Activity, CalendarDays, HelpCircle, LogOut, Receipt } from 'lucide-react'
+import { LayoutDashboard, FolderOpen, FileStack, Settings, Clock, BarChart3, Activity, CalendarDays, HelpCircle, LogOut, Receipt, Package } from 'lucide-react'
 import { useSupabase } from '@/hooks/use-supabase'
 import { cn } from '@/lib/utils'
 
@@ -17,6 +17,7 @@ const navItems = [
   { href: '/schedule', label: 'Schedule', icon: CalendarDays, adminOnly: false },
   { href: '/reports', label: 'Reports', icon: BarChart3, adminOnly: true },
   { href: '/invoices', label: 'Invoices', icon: Receipt, adminOnly: true },
+  { href: '/materials', label: 'Materials', icon: Package, adminOnly: true },
   { href: '/activity', label: 'Activity', icon: Activity, adminOnly: false },
   { href: '/templates', label: 'Templates', icon: FileStack, adminOnly: true },
   { href: '/settings', label: 'Settings', icon: Settings, adminOnly: true },

--- a/src/lib/api/admin.ts
+++ b/src/lib/api/admin.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+type RequireAdminOk = {
+  supabase: SupabaseClient
+  userId: string
+}
+
+type RequireAdminFail = { error: NextResponse }
+
+/**
+ * Server-side admin gate for API route handlers.
+ * Defense in depth — RLS already restricts admin tables, but the route
+ * shouldn't trust the request to make it to the DB layer.
+ */
+export async function requireAdmin(): Promise<RequireAdminOk | RequireAdminFail> {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return { error: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single()
+  if (profile?.role !== 'admin') {
+    return { error: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) }
+  }
+  return { supabase, userId: user.id }
+}


### PR DESCRIPTION
## Summary

Admin-only `/materials` page that turns the seed data from the schema PR into something Joe can actually use. Closes BlueWaveCreative/Operations#30.

- Server component admin gate; loads categories + active materials in parallel
- Grouped-by-category list, global search, per-category Add button
- Inline edit/delete (44x44 touch targets, focus rings, ARIA labels)
- Add/Edit Modal + dedicated delete-confirmation Modal (replaces native `confirm()`)
- Page-level error banner replaces `alert()`; `router.refresh()` preserves search state
- `/api/materials` POST + `/api/materials/[id]` PATCH/DELETE with shared `requireAdmin()` helper
- Soft-delete via `active=false` to preserve quote line item snapshots
- Soft-delete reactivation: re-adding a deleted material name flips `active=true` instead of inserting a duplicate
- Sidebar nav (admin-only) with `Package` icon

## Reviews incorporated

- **Aesthetic** — touch targets, focus rings, `router.refresh` over `reload()`, Modal-based delete confirmation, mobile row layout, empty/no-match states, zero-categories fallback. All P0/P1 addressed.
- **Critic** — shared `requireAdmin()`, 404 mapping (`PGRST116`), `parsePrice()` rejects empty strings, empty-id guards, form modal mid-submit dismiss guard. All P1/P2 addressed.

## Test plan

- [x] `npx tsc --noEmit` clean (after `.next/types` Finder-dupe cleanup)
- [x] Vercel preview build green (Dispatch verified `cca9824`)
- [ ] **Post-merge: apply migration `010_materials_quotes.sql` to Supabase** so the page can actually load data — currently the table doesn't exist in prod yet.
- [ ] Manual smoke after migration: load `/materials`, edit one row, delete one, re-add same name (verify reactivation), search, mobile width

## Next slices (M3)

1. CSV import/export for materials (#36, #37)
2. Quote builder UI wired to `computeQuoteTotals()` (#31, #32, #33)
3. Quote → Invoice conversion (#38), Quotes list (#39)

🤖 Generated with [Claude Code](https://claude.com/claude-code)