### PR TITLE
feat(m3): quote builder — list, create, full builder UI + API

### DIFF
--- a/src/app/(authenticated)/quotes/[id]/client.tsx
+++ b/src/app/(authenticated)/quotes/[id]/client.tsx
@@ -1,0 +1,603 @@
+'use client'
+
+import { useState, useMemo } from 'react'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { Card } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import {
+  Plus,
+  Trash2,
+  AlertCircle,
+  Send,
+  ArrowLeft,
+} from 'lucide-react'
+import { computeQuoteTotals } from '@/lib/quotes/calc'
+import type {
+  Quote,
+  QuoteLineItem,
+  QuoteStatus,
+  MaterialCategory,
+} from '@/lib/types/database'
+import { MaterialPickerModal, type PickerMaterial } from './material-picker'
+
+type QuoteWithJoins = Quote & {
+  customers: { name: string; email: string | null } | null
+  projects: { name: string } | null
+}
+
+interface QuoteBuilderClientProps {
+  quote: QuoteWithJoins
+  initialLineItems: QuoteLineItem[]
+  categories: MaterialCategory[]
+  materials: PickerMaterial[]
+}
+
+function formatCurrency(amount: number) {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+  }).format(amount)
+}
+
+function statusBadge(status: QuoteStatus) {
+  switch (status) {
+    case 'draft':
+      return <Badge variant="default">Draft</Badge>
+    case 'sent':
+      return <Badge variant="warning">Sent</Badge>
+    case 'accepted':
+      return <Badge variant="success">Accepted</Badge>
+    case 'declined':
+      return <Badge variant="default">Declined</Badge>
+    case 'expired':
+      return <Badge variant="default">Expired</Badge>
+    case 'converted':
+      return <Badge variant="success">Converted</Badge>
+  }
+}
+
+export function QuoteBuilderClient({
+  quote: initialQuote,
+  initialLineItems,
+  categories,
+  materials,
+}: QuoteBuilderClientProps) {
+  const router = useRouter()
+  const [quote, setQuote] = useState<QuoteWithJoins>(initialQuote)
+  const [lineItems, setLineItems] = useState<QuoteLineItem[]>(initialLineItems)
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [pickerOpen, setPickerOpen] = useState(false)
+
+  const readOnly = quote.status === 'converted'
+
+  const totals = useMemo(
+    () =>
+      computeQuoteTotals(lineItems, {
+        markup_enabled: quote.markup_enabled,
+        markup_percent: quote.markup_percent,
+        tax_enabled: quote.tax_enabled,
+        tax_percent: quote.tax_percent,
+        labor_rate: quote.labor_rate,
+        labor_hours: quote.labor_hours,
+        flat_fee_enabled: quote.flat_fee_enabled,
+        flat_fee: quote.flat_fee,
+      }),
+    [lineItems, quote],
+  )
+
+  // Group line items by phase, in the order phases first appear in `categories`
+  const groupedItems = useMemo(() => {
+    const map = new Map<string, QuoteLineItem[]>()
+    for (const cat of categories) map.set(cat.name, [])
+    for (const item of lineItems) {
+      if (!map.has(item.phase)) map.set(item.phase, [])
+      map.get(item.phase)!.push(item)
+    }
+    return [...map.entries()].filter(([, items]) => items.length > 0)
+  }, [lineItems, categories])
+
+  async function patchQuote(updates: Partial<Quote>) {
+    setBusy(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/quotes/${quote.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(updates),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error ?? 'Save failed')
+      setQuote({ ...quote, ...data.quote })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function addLineItem(materialId: string, quantity: number) {
+    setBusy(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/quotes/${quote.id}/line-items`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ material_id: materialId, quantity }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error ?? 'Add failed')
+      setLineItems([...lineItems, data.line_item])
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Add failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function updateLineItemQuantity(lineId: string, quantity: number) {
+    setBusy(true)
+    setError(null)
+    // Optimistic
+    setLineItems((prev) =>
+      prev.map((l) => (l.id === lineId ? { ...l, quantity } : l)),
+    )
+    try {
+      const res = await fetch(
+        `/api/quotes/${quote.id}/line-items/${lineId}`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ quantity }),
+        },
+      )
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error ?? 'Update failed')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Update failed')
+      // Refresh from server on failure
+      router.refresh()
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function deleteLineItem(lineId: string) {
+    setBusy(true)
+    setError(null)
+    try {
+      const res = await fetch(
+        `/api/quotes/${quote.id}/line-items/${lineId}`,
+        { method: 'DELETE' },
+      )
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error(data.error ?? 'Delete failed')
+      }
+      setLineItems((prev) => prev.filter((l) => l.id !== lineId))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Delete failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function handleSend() {
+    if (!confirm('Mark this quote as Sent?')) return
+    await patchQuote({ status: 'sent' })
+  }
+
+  return (
+    <div className="space-y-6 max-w-4xl">
+      <div className="flex items-center justify-between flex-wrap gap-3">
+        <Link
+          href="/quotes"
+          className="inline-flex items-center text-sm text-gray-600 hover:text-gray-900"
+        >
+          <ArrowLeft className="w-4 h-4 mr-1" /> All quotes
+        </Link>
+        {!readOnly && quote.status === 'draft' && (
+          <Button onClick={handleSend} disabled={busy || lineItems.length === 0}>
+            <Send className="w-4 h-4 mr-1" /> Mark as sent
+          </Button>
+        )}
+      </div>
+
+      {error && (
+        <div
+          role="alert"
+          className="flex items-start gap-2 px-3 py-2 rounded-lg bg-red-50 border border-red-200 text-sm text-red-700"
+        >
+          <AlertCircle className="w-4 h-4 mt-0.5 shrink-0" />
+          <span className="flex-1">{error}</span>
+          <button
+            onClick={() => setError(null)}
+            className="text-red-500 hover:text-red-700 text-xs font-medium"
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
+
+      <Card>
+        <div className="flex items-center justify-between gap-3 flex-wrap">
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 mb-1 flex-wrap">
+              <span className="text-xs text-gray-400 font-mono">
+                #{quote.quote_number}
+              </span>
+              {statusBadge(quote.status)}
+            </div>
+            <h2 className="text-lg font-semibold text-gray-900 truncate">
+              {quote.title}
+            </h2>
+            <p className="text-sm text-gray-500 truncate">
+              {quote.customers?.name ?? 'Unknown customer'}
+              {quote.projects ? ` · ${quote.projects.name}` : ''}
+            </p>
+          </div>
+          <div className="text-right">
+            <p className="text-xs text-gray-500">Grand total</p>
+            <p className="text-2xl font-bold text-gray-900 tabular-nums">
+              {formatCurrency(totals.grandTotal)}
+            </p>
+          </div>
+        </div>
+        {quote.description && (
+          <p className="mt-3 text-sm text-gray-600 border-t border-gray-100 pt-3">
+            <span className="font-medium">Customer-facing description:</span>{' '}
+            {quote.description}
+          </p>
+        )}
+      </Card>
+
+      {/* Line items */}
+      <Card className="p-0 overflow-hidden">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200 bg-gray-50">
+          <h3 className="text-base font-semibold text-gray-900">Line items</h3>
+          {!readOnly && (
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={() => setPickerOpen(true)}
+              disabled={busy}
+            >
+              <Plus className="w-4 h-4 mr-1" /> Add material
+            </Button>
+          )}
+        </div>
+
+        {lineItems.length === 0 ? (
+          <p className="text-sm text-gray-500 px-4 py-8 text-center">
+            No line items yet. Add a material to start building this quote.
+          </p>
+        ) : (
+          <div className="divide-y divide-gray-200">
+            {groupedItems.map(([phase, items]) => {
+              const phaseSubtotal = items.reduce(
+                (sum, l) => sum + Number(l.unit_price) * Number(l.quantity),
+                0,
+              )
+              return (
+                <div key={phase}>
+                  <div className="flex items-center justify-between px-4 py-2 bg-gray-50">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-gray-600">
+                      {phase}
+                    </p>
+                    <p className="text-xs text-gray-500 tabular-nums">
+                      {formatCurrency(phaseSubtotal)}
+                    </p>
+                  </div>
+                  <ul className="divide-y divide-gray-100">
+                    {items.map((item) => (
+                      <LineItemRow
+                        key={item.id}
+                        item={item}
+                        readOnly={readOnly}
+                        onQuantityChange={(qty) =>
+                          updateLineItemQuantity(item.id, qty)
+                        }
+                        onDelete={() => deleteLineItem(item.id)}
+                      />
+                    ))}
+                  </ul>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </Card>
+
+      {/* Pricing knobs */}
+      <Card>
+        <h3 className="text-base font-semibold text-gray-900 mb-3">Pricing</h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <ToggleNumber
+            label="Markup (materials only)"
+            suffix="%"
+            enabled={quote.markup_enabled}
+            value={quote.markup_percent}
+            disabled={readOnly}
+            onChange={(enabled, value) =>
+              patchQuote({ markup_enabled: enabled, markup_percent: value })
+            }
+          />
+          <ToggleNumber
+            label="Sales tax"
+            suffix="%"
+            enabled={quote.tax_enabled}
+            value={quote.tax_percent}
+            disabled={readOnly}
+            onChange={(enabled, value) =>
+              patchQuote({ tax_enabled: enabled, tax_percent: value })
+            }
+          />
+          <NumberInput
+            label="Labor rate"
+            prefix="$"
+            suffix="/ hr"
+            value={quote.labor_rate}
+            disabled={readOnly}
+            onChange={(value) => patchQuote({ labor_rate: value })}
+          />
+          <NumberInput
+            label="Labor hours"
+            value={quote.labor_hours}
+            disabled={readOnly}
+            onChange={(value) => patchQuote({ labor_hours: value })}
+          />
+          <ToggleNumber
+            label="Flat fee (trip / call-out)"
+            prefix="$"
+            enabled={quote.flat_fee_enabled}
+            value={quote.flat_fee}
+            disabled={readOnly}
+            onChange={(enabled, value) =>
+              patchQuote({ flat_fee_enabled: enabled, flat_fee: value })
+            }
+          />
+        </div>
+      </Card>
+
+      {/* Totals breakdown */}
+      <Card>
+        <h3 className="text-base font-semibold text-gray-900 mb-3">Totals</h3>
+        <dl className="space-y-1.5 text-sm">
+          <TotalsRow label="Materials" value={totals.materialsTotal} />
+          {quote.markup_enabled && totals.markupAmount > 0 && (
+            <TotalsRow
+              label={`Markup (${quote.markup_percent}%)`}
+              value={totals.markupAmount}
+            />
+          )}
+          {totals.laborAmount > 0 && (
+            <TotalsRow label="Labor" value={totals.laborAmount} />
+          )}
+          {quote.flat_fee_enabled && totals.flatFeeAmount > 0 && (
+            <TotalsRow label="Flat fee" value={totals.flatFeeAmount} />
+          )}
+          <TotalsRow
+            label="Subtotal"
+            value={totals.subtotalBeforeTax}
+            bold
+          />
+          {quote.tax_enabled && totals.taxAmount > 0 && (
+            <TotalsRow
+              label={`Tax (${quote.tax_percent}%)`}
+              value={totals.taxAmount}
+            />
+          )}
+          <div className="border-t border-gray-200 pt-2 mt-2">
+            <TotalsRow label="Grand total" value={totals.grandTotal} large />
+          </div>
+        </dl>
+      </Card>
+
+      <MaterialPickerModal
+        open={pickerOpen}
+        onClose={() => setPickerOpen(false)}
+        categories={categories}
+        materials={materials}
+        onAdd={addLineItem}
+      />
+    </div>
+  )
+}
+
+function LineItemRow({
+  item,
+  readOnly,
+  onQuantityChange,
+  onDelete,
+}: {
+  item: QuoteLineItem
+  readOnly: boolean
+  onQuantityChange: (qty: number) => void
+  onDelete: () => void
+}) {
+  const [draft, setDraft] = useState(String(item.quantity))
+
+  return (
+    <li className="flex items-center gap-3 px-4 py-2.5">
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-gray-900 truncate">
+          {item.material_name}
+        </p>
+        <p className="text-xs text-gray-500">
+          {formatCurrency(Number(item.unit_price))} per {item.unit}
+        </p>
+      </div>
+      <div className="flex items-center gap-1">
+        <input
+          id={`qty-${item.id}`}
+          type="number"
+          step="0.01"
+          min="0"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={() => {
+            const n = Number(draft)
+            if (!Number.isFinite(n) || n < 0) {
+              setDraft(String(item.quantity))
+              return
+            }
+            if (n !== Number(item.quantity)) onQuantityChange(n)
+          }}
+          disabled={readOnly}
+          aria-label={`Quantity for ${item.material_name}`}
+          className="w-20 px-2 py-1 border border-gray-300 rounded text-sm text-right tabular-nums focus:outline-none focus:ring-2 focus:ring-[#68BD45] focus:border-transparent disabled:bg-gray-50 disabled:text-gray-500"
+        />
+      </div>
+      <p className="text-sm font-semibold text-gray-900 tabular-nums w-24 text-right shrink-0">
+        {formatCurrency(Number(item.unit_price) * Number(item.quantity))}
+      </p>
+      {!readOnly && (
+        <button
+          type="button"
+          onClick={onDelete}
+          className="inline-flex items-center justify-center w-11 h-11 rounded-lg text-gray-500 hover:bg-red-50 hover:text-red-600 transition-colors focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-[#68BD45]"
+          aria-label={`Remove ${item.material_name}`}
+        >
+          <Trash2 className="w-4 h-4" />
+        </button>
+      )}
+    </li>
+  )
+}
+
+function ToggleNumber({
+  label,
+  enabled,
+  value,
+  disabled,
+  prefix,
+  suffix,
+  onChange,
+}: {
+  label: string
+  enabled: boolean
+  value: number
+  disabled: boolean
+  prefix?: string
+  suffix?: string
+  onChange: (enabled: boolean, value: number) => void
+}) {
+  const [draft, setDraft] = useState(String(value))
+  return (
+    <div>
+      <label className="flex items-center gap-2 text-sm font-medium text-gray-700 mb-1">
+        <input
+          type="checkbox"
+          checked={enabled}
+          disabled={disabled}
+          onChange={(e) => onChange(e.target.checked, value)}
+          className="rounded border-gray-300 text-[#68BD45] focus:ring-[#68BD45]"
+        />
+        {label}
+      </label>
+      <div className="flex items-center gap-1 text-sm">
+        {prefix && <span className="text-gray-500">{prefix}</span>}
+        <input
+          type="number"
+          step="0.01"
+          min="0"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={() => {
+            const n = Number(draft)
+            if (!Number.isFinite(n) || n < 0) {
+              setDraft(String(value))
+              return
+            }
+            if (n !== Number(value)) onChange(enabled, n)
+          }}
+          disabled={disabled || !enabled}
+          className="flex-1 px-2 py-1 border border-gray-300 rounded text-sm text-right tabular-nums focus:outline-none focus:ring-2 focus:ring-[#68BD45] focus:border-transparent disabled:bg-gray-50 disabled:text-gray-400"
+        />
+        {suffix && <span className="text-gray-500">{suffix}</span>}
+      </div>
+    </div>
+  )
+}
+
+function NumberInput({
+  label,
+  value,
+  disabled,
+  prefix,
+  suffix,
+  onChange,
+}: {
+  label: string
+  value: number
+  disabled: boolean
+  prefix?: string
+  suffix?: string
+  onChange: (value: number) => void
+}) {
+  const [draft, setDraft] = useState(String(value))
+  return (
+    <div>
+      <p className="text-sm font-medium text-gray-700 mb-1">{label}</p>
+      <div className="flex items-center gap-1 text-sm">
+        {prefix && <span className="text-gray-500">{prefix}</span>}
+        <input
+          type="number"
+          step="0.01"
+          min="0"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={() => {
+            const n = Number(draft)
+            if (!Number.isFinite(n) || n < 0) {
+              setDraft(String(value))
+              return
+            }
+            if (n !== Number(value)) onChange(n)
+          }}
+          disabled={disabled}
+          aria-label={label}
+          className="flex-1 px-2 py-1 border border-gray-300 rounded text-sm text-right tabular-nums focus:outline-none focus:ring-2 focus:ring-[#68BD45] focus:border-transparent disabled:bg-gray-50 disabled:text-gray-400"
+        />
+        {suffix && <span className="text-gray-500">{suffix}</span>}
+      </div>
+    </div>
+  )
+}
+
+function TotalsRow({
+  label,
+  value,
+  bold,
+  large,
+}: {
+  label: string
+  value: number
+  bold?: boolean
+  large?: boolean
+}) {
+  return (
+    <div
+      className={`flex items-center justify-between ${
+        large ? 'text-base' : ''
+      }`}
+    >
+      <dt
+        className={`text-gray-${bold || large ? '900' : '600'} ${
+          bold || large ? 'font-semibold' : ''
+        }`}
+      >
+        {label}
+      </dt>
+      <dd
+        className={`tabular-nums text-gray-${bold || large ? '900' : '700'} ${
+          bold || large ? 'font-semibold' : ''
+        }`}
+      >
+        {formatCurrency(value)}
+      </dd>
+    </div>
+  )
+}

--- a/src/app/(authenticated)/quotes/[id]/client.tsx
+++ b/src/app/(authenticated)/quotes/[id]/client.tsx
@@ -1,17 +1,19 @@
 'use client'
 
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect, useRef } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { Card } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
+import { Modal } from '@/components/ui/modal'
 import {
   Plus,
   Trash2,
   AlertCircle,
   Send,
   ArrowLeft,
+  Lock,
 } from 'lucide-react'
 import { computeQuoteTotals } from '@/lib/quotes/calc'
 import type {
@@ -50,11 +52,15 @@ function statusBadge(status: QuoteStatus) {
     case 'accepted':
       return <Badge variant="success">Accepted</Badge>
     case 'declined':
-      return <Badge variant="default">Declined</Badge>
+      return <Badge variant="danger">Declined</Badge>
     case 'expired':
-      return <Badge variant="default">Expired</Badge>
+      return (
+        <Badge variant="default" className="line-through">
+          Expired
+        </Badge>
+      )
     case 'converted':
-      return <Badge variant="success">Converted</Badge>
+      return <Badge variant="info">Converted</Badge>
   }
 }
 
@@ -70,6 +76,18 @@ export function QuoteBuilderClient({
   const [error, setError] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
   const [pickerOpen, setPickerOpen] = useState(false)
+  const [sendConfirmOpen, setSendConfirmOpen] = useState(false)
+
+  // Sync local state with server props (covers router.refresh() flows)
+  useEffect(() => {
+    setQuote(initialQuote)
+  }, [initialQuote])
+  useEffect(() => {
+    setLineItems(initialLineItems)
+  }, [initialLineItems])
+
+  // Per-line abort controller, so a fresh quantity blur cancels any in-flight one.
+  const lineAborters = useRef<Map<string, AbortController>>(new Map())
 
   const readOnly = quote.status === 'converted'
 
@@ -88,7 +106,6 @@ export function QuoteBuilderClient({
     [lineItems, quote],
   )
 
-  // Group line items by phase, in the order phases first appear in `categories`
   const groupedItems = useMemo(() => {
     const map = new Map<string, QuoteLineItem[]>()
     for (const cat of categories) map.set(cat.name, [])
@@ -110,9 +127,10 @@ export function QuoteBuilderClient({
       })
       const data = await res.json()
       if (!res.ok) throw new Error(data.error ?? 'Save failed')
-      setQuote({ ...quote, ...data.quote })
+      setQuote((prev) => ({ ...prev, ...data.quote }))
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Save failed')
+      router.refresh()
     } finally {
       setBusy(false)
     }
@@ -129,7 +147,7 @@ export function QuoteBuilderClient({
       })
       const data = await res.json()
       if (!res.ok) throw new Error(data.error ?? 'Add failed')
-      setLineItems([...lineItems, data.line_item])
+      setLineItems((prev) => [...prev, data.line_item])
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Add failed')
     } finally {
@@ -138,12 +156,18 @@ export function QuoteBuilderClient({
   }
 
   async function updateLineItemQuantity(lineId: string, quantity: number) {
-    setBusy(true)
-    setError(null)
-    // Optimistic
+    // Cancel any in-flight request for this line.
+    const prior = lineAborters.current.get(lineId)
+    if (prior) prior.abort()
+    const controller = new AbortController()
+    lineAborters.current.set(lineId, controller)
+
+    // Optimistic update so totals respond immediately.
     setLineItems((prev) =>
       prev.map((l) => (l.id === lineId ? { ...l, quantity } : l)),
     )
+    setError(null)
+
     try {
       const res = await fetch(
         `/api/quotes/${quote.id}/line-items/${lineId}`,
@@ -151,16 +175,23 @@ export function QuoteBuilderClient({
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ quantity }),
+          signal: controller.signal,
         },
       )
       const data = await res.json()
       if (!res.ok) throw new Error(data.error ?? 'Update failed')
+      // Reconcile with server response (rounded NUMERIC, etc.)
+      setLineItems((prev) =>
+        prev.map((l) => (l.id === lineId ? data.line_item : l)),
+      )
     } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') return
       setError(err instanceof Error ? err.message : 'Update failed')
-      // Refresh from server on failure
       router.refresh()
     } finally {
-      setBusy(false)
+      if (lineAborters.current.get(lineId) === controller) {
+        lineAborters.current.delete(lineId)
+      }
     }
   }
 
@@ -184,8 +215,8 @@ export function QuoteBuilderClient({
     }
   }
 
-  async function handleSend() {
-    if (!confirm('Mark this quote as Sent?')) return
+  async function confirmSend() {
+    setSendConfirmOpen(false)
     await patchQuote({ status: 'sent' })
   }
 
@@ -194,16 +225,37 @@ export function QuoteBuilderClient({
       <div className="flex items-center justify-between flex-wrap gap-3">
         <Link
           href="/quotes"
-          className="inline-flex items-center text-sm text-gray-600 hover:text-gray-900"
+          className="inline-flex items-center text-sm text-gray-600 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-[#68BD45] rounded"
         >
           <ArrowLeft className="w-4 h-4 mr-1" /> All quotes
         </Link>
         {!readOnly && quote.status === 'draft' && (
-          <Button onClick={handleSend} disabled={busy || lineItems.length === 0}>
+          <Button
+            onClick={() => setSendConfirmOpen(true)}
+            disabled={busy || lineItems.length === 0}
+            title={
+              lineItems.length === 0
+                ? 'Add at least one line item before sending'
+                : undefined
+            }
+          >
             <Send className="w-4 h-4 mr-1" /> Mark as sent
           </Button>
         )}
       </div>
+
+      {readOnly && (
+        <div
+          role="status"
+          className="flex items-start gap-2 px-3 py-2 rounded-lg bg-yellow-50 border border-yellow-200 text-sm text-yellow-800"
+        >
+          <Lock className="w-4 h-4 mt-0.5 shrink-0" />
+          <span>
+            This quote is locked because it was converted to an invoice. Line items
+            and pricing can&rsquo;t be edited.
+          </span>
+        </div>
+      )}
 
       {error && (
         <div
@@ -378,11 +430,7 @@ export function QuoteBuilderClient({
           {quote.flat_fee_enabled && totals.flatFeeAmount > 0 && (
             <TotalsRow label="Flat fee" value={totals.flatFeeAmount} />
           )}
-          <TotalsRow
-            label="Subtotal"
-            value={totals.subtotalBeforeTax}
-            bold
-          />
+          <TotalsRow label="Subtotal" value={totals.subtotalBeforeTax} bold />
           {quote.tax_enabled && totals.taxAmount > 0 && (
             <TotalsRow
               label={`Tax (${quote.tax_percent}%)`}
@@ -402,6 +450,33 @@ export function QuoteBuilderClient({
         materials={materials}
         onAdd={addLineItem}
       />
+
+      <Modal
+        open={sendConfirmOpen}
+        onClose={() => !busy && setSendConfirmOpen(false)}
+        title="Mark this quote as sent?"
+      >
+        <div className="space-y-4">
+          <p className="text-sm text-gray-700">
+            This will lock the quote into your <span className="font-semibold">Sent</span>{' '}
+            list and stamp the send time. You can still edit line items and pricing
+            until it&rsquo;s converted to an invoice.
+          </p>
+          <div className="flex justify-end gap-2">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => setSendConfirmOpen(false)}
+              disabled={busy}
+            >
+              Cancel
+            </Button>
+            <Button type="button" onClick={confirmSend} disabled={busy}>
+              {busy ? 'Saving…' : 'Yes, mark sent'}
+            </Button>
+          </div>
+        </div>
+      </Modal>
     </div>
   )
 }
@@ -418,10 +493,26 @@ function LineItemRow({
   onDelete: () => void
 }) {
   const [draft, setDraft] = useState(String(item.quantity))
+  const [focused, setFocused] = useState(false)
+
+  // Re-sync draft from server-confirmed prop, but only when the input isn't
+  // focused — avoid clobbering the user mid-type.
+  useEffect(() => {
+    if (!focused) setDraft(String(item.quantity))
+  }, [item.quantity, focused])
+
+  function commit() {
+    const n = Number(draft)
+    if (!Number.isFinite(n) || n < 0) {
+      setDraft(String(item.quantity))
+      return
+    }
+    if (n !== Number(item.quantity)) onQuantityChange(n)
+  }
 
   return (
-    <li className="flex items-center gap-3 px-4 py-2.5">
-      <div className="flex-1 min-w-0">
+    <li className="flex flex-wrap sm:flex-nowrap items-center gap-2 sm:gap-3 px-3 sm:px-4 py-2.5">
+      <div className="flex-1 min-w-0 w-full sm:w-auto">
         <p className="text-sm font-medium text-gray-900 truncate">
           {item.material_name}
         </p>
@@ -429,27 +520,28 @@ function LineItemRow({
           {formatCurrency(Number(item.unit_price))} per {item.unit}
         </p>
       </div>
-      <div className="flex items-center gap-1">
-        <input
-          id={`qty-${item.id}`}
-          type="number"
-          step="0.01"
-          min="0"
-          value={draft}
-          onChange={(e) => setDraft(e.target.value)}
-          onBlur={() => {
-            const n = Number(draft)
-            if (!Number.isFinite(n) || n < 0) {
-              setDraft(String(item.quantity))
-              return
-            }
-            if (n !== Number(item.quantity)) onQuantityChange(n)
-          }}
-          disabled={readOnly}
-          aria-label={`Quantity for ${item.material_name}`}
-          className="w-20 px-2 py-1 border border-gray-300 rounded text-sm text-right tabular-nums focus:outline-none focus:ring-2 focus:ring-[#68BD45] focus:border-transparent disabled:bg-gray-50 disabled:text-gray-500"
-        />
-      </div>
+      <input
+        id={`qty-${item.id}`}
+        type="number"
+        step="0.01"
+        min="0"
+        value={draft}
+        onFocus={() => setFocused(true)}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={() => {
+          setFocused(false)
+          commit()
+        }}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault()
+            ;(e.currentTarget as HTMLInputElement).blur()
+          }
+        }}
+        disabled={readOnly}
+        aria-label={`Quantity for ${item.material_name}`}
+        className="w-20 px-2 py-1 border border-gray-300 rounded text-sm text-right tabular-nums focus:outline-none focus:ring-2 focus:ring-[#68BD45] focus:border-transparent disabled:bg-gray-50 disabled:text-gray-500"
+      />
       <p className="text-sm font-semibold text-gray-900 tabular-nums w-24 text-right shrink-0">
         {formatCurrency(Number(item.unit_price) * Number(item.quantity))}
       </p>
@@ -485,6 +577,21 @@ function ToggleNumber({
   onChange: (enabled: boolean, value: number) => void
 }) {
   const [draft, setDraft] = useState(String(value))
+  const [focused, setFocused] = useState(false)
+
+  useEffect(() => {
+    if (!focused) setDraft(String(value))
+  }, [value, focused])
+
+  function commit() {
+    const n = Number(draft)
+    if (!Number.isFinite(n) || n < 0) {
+      setDraft(String(value))
+      return
+    }
+    if (n !== Number(value)) onChange(enabled, n)
+  }
+
   return (
     <div>
       <label className="flex items-center gap-2 text-sm font-medium text-gray-700 mb-1">
@@ -495,7 +602,10 @@ function ToggleNumber({
           onChange={(e) => onChange(e.target.checked, value)}
           className="rounded border-gray-300 text-[#68BD45] focus:ring-[#68BD45]"
         />
-        {label}
+        <span>{label}</span>
+        {!enabled && (
+          <span className="text-xs font-normal text-gray-400">(not applied)</span>
+        )}
       </label>
       <div className="flex items-center gap-1 text-sm">
         {prefix && <span className="text-gray-500">{prefix}</span>}
@@ -504,16 +614,20 @@ function ToggleNumber({
           step="0.01"
           min="0"
           value={draft}
+          onFocus={() => setFocused(true)}
           onChange={(e) => setDraft(e.target.value)}
           onBlur={() => {
-            const n = Number(draft)
-            if (!Number.isFinite(n) || n < 0) {
-              setDraft(String(value))
-              return
+            setFocused(false)
+            commit()
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault()
+              ;(e.currentTarget as HTMLInputElement).blur()
             }
-            if (n !== Number(value)) onChange(enabled, n)
           }}
           disabled={disabled || !enabled}
+          aria-label={label}
           className="flex-1 px-2 py-1 border border-gray-300 rounded text-sm text-right tabular-nums focus:outline-none focus:ring-2 focus:ring-[#68BD45] focus:border-transparent disabled:bg-gray-50 disabled:text-gray-400"
         />
         {suffix && <span className="text-gray-500">{suffix}</span>}
@@ -538,6 +652,21 @@ function NumberInput({
   onChange: (value: number) => void
 }) {
   const [draft, setDraft] = useState(String(value))
+  const [focused, setFocused] = useState(false)
+
+  useEffect(() => {
+    if (!focused) setDraft(String(value))
+  }, [value, focused])
+
+  function commit() {
+    const n = Number(draft)
+    if (!Number.isFinite(n) || n < 0) {
+      setDraft(String(value))
+      return
+    }
+    if (n !== Number(value)) onChange(n)
+  }
+
   return (
     <div>
       <p className="text-sm font-medium text-gray-700 mb-1">{label}</p>
@@ -548,14 +677,17 @@ function NumberInput({
           step="0.01"
           min="0"
           value={draft}
+          onFocus={() => setFocused(true)}
           onChange={(e) => setDraft(e.target.value)}
           onBlur={() => {
-            const n = Number(draft)
-            if (!Number.isFinite(n) || n < 0) {
-              setDraft(String(value))
-              return
+            setFocused(false)
+            commit()
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault()
+              ;(e.currentTarget as HTMLInputElement).blur()
             }
-            if (n !== Number(value)) onChange(n)
           }}
           disabled={disabled}
           aria-label={label}
@@ -578,22 +710,15 @@ function TotalsRow({
   bold?: boolean
   large?: boolean
 }) {
+  const emphasis = bold || large
   return (
-    <div
-      className={`flex items-center justify-between ${
-        large ? 'text-base' : ''
-      }`}
-    >
-      <dt
-        className={`text-gray-${bold || large ? '900' : '600'} ${
-          bold || large ? 'font-semibold' : ''
-        }`}
-      >
+    <div className={`flex items-center justify-between ${large ? 'text-base' : ''}`}>
+      <dt className={emphasis ? 'text-gray-900 font-semibold' : 'text-gray-600'}>
         {label}
       </dt>
       <dd
-        className={`tabular-nums text-gray-${bold || large ? '900' : '700'} ${
-          bold || large ? 'font-semibold' : ''
+        className={`tabular-nums ${
+          emphasis ? 'text-gray-900 font-semibold' : 'text-gray-700'
         }`}
       >
         {formatCurrency(value)}

--- a/src/app/(authenticated)/quotes/[id]/material-picker.tsx
+++ b/src/app/(authenticated)/quotes/[id]/material-picker.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect } from 'react'
 import { Modal } from '@/components/ui/modal'
 import { Button } from '@/components/ui/button'
 import { Search, Plus } from 'lucide-react'
@@ -66,9 +66,13 @@ export function MaterialPickerModal({
     setError(null)
   }
 
+  // Reset state any time the modal becomes hidden, regardless of close path.
+  useEffect(() => {
+    if (!open) reset()
+  }, [open])
+
   function handleClose() {
     if (submitting) return
-    reset()
     onClose()
   }
 
@@ -166,7 +170,7 @@ export function MaterialPickerModal({
             />
           </div>
 
-          <div className="border border-gray-200 rounded-lg max-h-[400px] overflow-y-auto">
+          <div className="border border-gray-200 rounded-lg max-h-[min(400px,60vh)] overflow-y-auto">
             {categories.length === 0 || materials.length === 0 ? (
               <p className="text-sm text-gray-500 text-center py-8">
                 No materials available. Add materials in the{' '}
@@ -191,7 +195,7 @@ export function MaterialPickerModal({
                             <button
                               type="button"
                               onClick={() => setSelected(m)}
-                              className="w-full flex items-center gap-3 px-3 py-2 text-left hover:bg-gray-50 focus:outline-none focus:bg-gray-100"
+                              className="w-full flex items-center gap-3 px-3 py-3 min-h-[44px] text-left hover:bg-gray-50 focus:outline-none focus:bg-gray-100 focus:ring-2 focus:ring-[#68BD45] focus:ring-inset"
                             >
                               <div className="flex-1 min-w-0">
                                 <p className="text-sm text-gray-900 truncate">

--- a/src/app/(authenticated)/quotes/[id]/material-picker.tsx
+++ b/src/app/(authenticated)/quotes/[id]/material-picker.tsx
@@ -1,0 +1,227 @@
+'use client'
+
+import { useState, useMemo } from 'react'
+import { Modal } from '@/components/ui/modal'
+import { Button } from '@/components/ui/button'
+import { Search, Plus } from 'lucide-react'
+import type { MaterialCategory } from '@/lib/types/database'
+
+export type PickerMaterial = {
+  id: string
+  name: string
+  unit: string
+  price: number
+  category_id: string
+  sort_order: number
+}
+
+interface MaterialPickerModalProps {
+  open: boolean
+  onClose: () => void
+  categories: MaterialCategory[]
+  materials: PickerMaterial[]
+  onAdd: (materialId: string, quantity: number) => Promise<void> | void
+}
+
+function formatCurrency(amount: number) {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+  }).format(amount)
+}
+
+export function MaterialPickerModal({
+  open,
+  onClose,
+  categories,
+  materials,
+  onAdd,
+}: MaterialPickerModalProps) {
+  const [search, setSearch] = useState('')
+  const [selected, setSelected] = useState<PickerMaterial | null>(null)
+  const [quantity, setQuantity] = useState('1')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const filtered = useMemo(() => {
+    if (!search.trim()) return materials
+    const q = search.toLowerCase()
+    return materials.filter((m) => m.name.toLowerCase().includes(q))
+  }, [materials, search])
+
+  const grouped = useMemo(() => {
+    const map = new Map<string, PickerMaterial[]>()
+    for (const cat of categories) map.set(cat.id, [])
+    for (const m of filtered) {
+      const list = map.get(m.category_id)
+      if (list) list.push(m)
+    }
+    return map
+  }, [categories, filtered])
+
+  function reset() {
+    setSearch('')
+    setSelected(null)
+    setQuantity('1')
+    setError(null)
+  }
+
+  function handleClose() {
+    if (submitting) return
+    reset()
+    onClose()
+  }
+
+  async function handleAdd() {
+    if (!selected) return
+    const n = Number(quantity)
+    if (!Number.isFinite(n) || n <= 0) {
+      setError('Quantity must be greater than 0.')
+      return
+    }
+    setSubmitting(true)
+    setError(null)
+    try {
+      await onAdd(selected.id, n)
+      reset()
+      onClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to add')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Modal
+      open={open}
+      onClose={handleClose}
+      title={selected ? `Add ${selected.name}` : 'Add material'}
+      className="max-w-2xl"
+    >
+      {selected ? (
+        <div className="space-y-4">
+          <div className="bg-gray-50 rounded-lg px-3 py-2">
+            <p className="text-sm font-medium text-gray-900">{selected.name}</p>
+            <p className="text-xs text-gray-500">
+              {formatCurrency(Number(selected.price))} per {selected.unit}
+            </p>
+          </div>
+          <div>
+            <label
+              htmlFor="picker-qty"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              Quantity ({selected.unit})
+            </label>
+            <input
+              id="picker-qty"
+              type="number"
+              step="0.01"
+              min="0.01"
+              value={quantity}
+              onChange={(e) => setQuantity(e.target.value)}
+              autoFocus
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#68BD45] focus:border-transparent text-sm tabular-nums"
+            />
+          </div>
+          {error && (
+            <p role="alert" className="text-sm text-red-600">
+              {error}
+            </p>
+          )}
+          <div className="flex justify-between gap-2 pt-2">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => {
+                setSelected(null)
+                setError(null)
+              }}
+            >
+              ← Pick a different material
+            </Button>
+            <div className="flex gap-2">
+              <Button type="button" variant="secondary" onClick={handleClose}>
+                Cancel
+              </Button>
+              <Button type="button" onClick={handleAdd} disabled={submitting}>
+                {submitting ? 'Adding…' : 'Add to quote'}
+              </Button>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
+            <input
+              type="search"
+              placeholder="Search materials…"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              autoFocus
+              aria-label="Search materials"
+              className="w-full pl-9 pr-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#68BD45] focus:border-transparent text-sm"
+            />
+          </div>
+
+          <div className="border border-gray-200 rounded-lg max-h-[400px] overflow-y-auto">
+            {categories.length === 0 || materials.length === 0 ? (
+              <p className="text-sm text-gray-500 text-center py-8">
+                No materials available. Add materials in the{' '}
+                <a href="/materials" className="text-[#68BD45] hover:underline">
+                  Materials
+                </a>{' '}
+                page first.
+              </p>
+            ) : (
+              <ul className="divide-y divide-gray-100">
+                {categories.map((cat) => {
+                  const items = grouped.get(cat.id) ?? []
+                  if (items.length === 0) return null
+                  return (
+                    <li key={cat.id}>
+                      <p className="px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-gray-600 bg-gray-50 sticky top-0">
+                        {cat.name}
+                      </p>
+                      <ul className="divide-y divide-gray-100">
+                        {items.map((m) => (
+                          <li key={m.id}>
+                            <button
+                              type="button"
+                              onClick={() => setSelected(m)}
+                              className="w-full flex items-center gap-3 px-3 py-2 text-left hover:bg-gray-50 focus:outline-none focus:bg-gray-100"
+                            >
+                              <div className="flex-1 min-w-0">
+                                <p className="text-sm text-gray-900 truncate">
+                                  {m.name}
+                                </p>
+                                <p className="text-xs text-gray-500">
+                                  per {m.unit}
+                                </p>
+                              </div>
+                              <p className="text-sm font-medium text-gray-900 tabular-nums shrink-0">
+                                {formatCurrency(Number(m.price))}
+                              </p>
+                              <Plus className="w-4 h-4 text-gray-400 shrink-0" />
+                            </button>
+                          </li>
+                        ))}
+                      </ul>
+                    </li>
+                  )
+                })}
+                {filtered.length === 0 && (
+                  <li className="text-sm text-gray-500 text-center py-6">
+                    No matches for &ldquo;{search}&rdquo;.
+                  </li>
+                )}
+              </ul>
+            )}
+          </div>
+        </div>
+      )}
+    </Modal>
+  )
+}

--- a/src/app/(authenticated)/quotes/[id]/page.tsx
+++ b/src/app/(authenticated)/quotes/[id]/page.tsx
@@ -1,0 +1,70 @@
+export const dynamic = 'force-dynamic'
+
+import { redirect, notFound } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
+import { PageHeader } from '@/components/layout/page-header'
+import { QuoteBuilderClient } from './client'
+
+export default async function QuotePage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) redirect('/login')
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single()
+  if (profile?.role !== 'admin') redirect('/dashboard')
+
+  const [
+    { data: quote },
+    { data: lineItems },
+    { data: categories },
+    { data: materials },
+  ] = await Promise.all([
+    supabase
+      .from('quotes')
+      .select('*, customers(name, email), projects(name)')
+      .eq('id', id)
+      .maybeSingle(),
+    supabase
+      .from('quote_line_items')
+      .select('*')
+      .eq('quote_id', id)
+      .order('sort_order', { ascending: true }),
+    supabase
+      .from('material_categories')
+      .select('*')
+      .order('sort_order', { ascending: true }),
+    supabase
+      .from('materials')
+      .select('id, name, unit, price, category_id, sort_order')
+      .eq('active', true)
+      .order('sort_order', { ascending: true }),
+  ])
+
+  if (!quote) notFound()
+
+  return (
+    <div>
+      <PageHeader title={`Quote #${quote.quote_number}`} />
+      <div className="p-4 md:p-6">
+        <QuoteBuilderClient
+          quote={quote as unknown as Parameters<typeof QuoteBuilderClient>[0]['quote']}
+          initialLineItems={lineItems ?? []}
+          categories={categories ?? []}
+          materials={materials ?? []}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/app/(authenticated)/quotes/client.tsx
+++ b/src/app/(authenticated)/quotes/client.tsx
@@ -56,11 +56,15 @@ function statusBadge(status: QuoteStatus) {
     case 'accepted':
       return <Badge variant="success">Accepted</Badge>
     case 'declined':
-      return <Badge variant="default">Declined</Badge>
+      return <Badge variant="danger">Declined</Badge>
     case 'expired':
-      return <Badge variant="default">Expired</Badge>
+      return (
+        <Badge variant="default" className="line-through">
+          Expired
+        </Badge>
+      )
     case 'converted':
-      return <Badge variant="success">Converted</Badge>
+      return <Badge variant="info">Converted</Badge>
   }
 }
 
@@ -105,11 +109,21 @@ export function QuotesClient({ quotes }: QuotesClientProps) {
 
       {filtered.length === 0 ? (
         <Card>
-          <p className="text-gray-500 text-sm text-center py-4">
-            {quotes.length === 0
-              ? 'No quotes yet. Create one to get started.'
-              : `No ${activeTab} quotes.`}
-          </p>
+          <div className="text-center py-6 space-y-3">
+            <p className="text-gray-500 text-sm">
+              {quotes.length === 0
+                ? 'No quotes yet. Create one to get started.'
+                : `No ${activeTab} quotes.`}
+            </p>
+            {quotes.length === 0 && (
+              <Link
+                href="/quotes/new"
+                className="inline-flex items-center px-4 py-2 text-sm font-medium rounded-xl bg-[#68BD45] text-white hover:bg-[#5aa83c] focus:outline-none focus:ring-2 focus:ring-[#68BD45] focus:ring-offset-2"
+              >
+                <Plus className="w-4 h-4 mr-1" /> New quote
+              </Link>
+            )}
+          </div>
         </Card>
       ) : (
         <div className="space-y-2">
@@ -125,7 +139,12 @@ export function QuotesClient({ quotes }: QuotesClientProps) {
               flat_fee: q.flat_fee,
             })
             return (
-              <Link key={q.id} href={`/quotes/${q.id}`}>
+              <Link
+                key={q.id}
+                href={`/quotes/${q.id}`}
+                aria-label={`Open quote #${q.quote_number}: ${q.title}`}
+                className="block focus:outline-none focus:ring-2 focus:ring-[#68BD45] focus:ring-offset-2 rounded-xl"
+              >
                 <Card className="hover:shadow-md transition-shadow cursor-pointer">
                   <div className="flex items-center justify-between gap-4">
                     <div className="flex-1 min-w-0">

--- a/src/app/(authenticated)/quotes/client.tsx
+++ b/src/app/(authenticated)/quotes/client.tsx
@@ -1,0 +1,167 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { Card } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Plus } from 'lucide-react'
+import { computeQuoteTotals } from '@/lib/quotes/calc'
+import type { QuoteStatus, QuoteJobType } from '@/lib/types/database'
+
+type QuoteRow = {
+  id: string
+  quote_number: number
+  title: string
+  status: QuoteStatus
+  job_type: QuoteJobType
+  issued_date: string
+  valid_until: string | null
+  markup_enabled: boolean
+  markup_percent: number
+  tax_enabled: boolean
+  tax_percent: number
+  labor_rate: number
+  labor_hours: number
+  flat_fee_enabled: boolean
+  flat_fee: number
+  customers: { name: string } | null
+  projects: { name: string } | null
+  quote_line_items: { quantity: number; unit_price: number }[]
+}
+
+interface QuotesClientProps {
+  quotes: QuoteRow[]
+}
+
+const STATUS_TABS: { label: string; value: 'all' | QuoteStatus }[] = [
+  { label: 'All', value: 'all' },
+  { label: 'Draft', value: 'draft' },
+  { label: 'Sent', value: 'sent' },
+  { label: 'Accepted', value: 'accepted' },
+  { label: 'Converted', value: 'converted' },
+]
+
+const JOB_TYPE_LABEL: Record<QuoteJobType, string> = {
+  rough_in: 'Rough-In',
+  trim_out: 'Trim-Out',
+  service: 'Service',
+}
+
+function statusBadge(status: QuoteStatus) {
+  switch (status) {
+    case 'draft':
+      return <Badge variant="default">Draft</Badge>
+    case 'sent':
+      return <Badge variant="warning">Sent</Badge>
+    case 'accepted':
+      return <Badge variant="success">Accepted</Badge>
+    case 'declined':
+      return <Badge variant="default">Declined</Badge>
+    case 'expired':
+      return <Badge variant="default">Expired</Badge>
+    case 'converted':
+      return <Badge variant="success">Converted</Badge>
+  }
+}
+
+function formatCurrency(amount: number) {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+  }).format(amount)
+}
+
+export function QuotesClient({ quotes }: QuotesClientProps) {
+  const [activeTab, setActiveTab] = useState<'all' | QuoteStatus>('all')
+
+  const filtered =
+    activeTab === 'all' ? quotes : quotes.filter((q) => q.status === activeTab)
+
+  return (
+    <div className="space-y-4 max-w-4xl">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <div className="flex gap-2 flex-wrap">
+          {STATUS_TABS.map((tab) => (
+            <button
+              key={tab.value}
+              onClick={() => setActiveTab(tab.value)}
+              className={`px-4 py-1.5 rounded-full text-sm font-medium transition-colors ${
+                activeTab === tab.value
+                  ? 'bg-[#68BD45] text-white'
+                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+        <Link
+          href="/quotes/new"
+          className="inline-flex items-center px-4 py-2 text-sm font-medium rounded-xl bg-[#68BD45] text-white hover:bg-[#5aa83c] transition-colors shadow-sm hover:shadow-md focus:outline-none focus:ring-2 focus:ring-[#68BD45] focus:ring-offset-2"
+        >
+          <Plus className="w-4 h-4 mr-2" /> New Quote
+        </Link>
+      </div>
+
+      {filtered.length === 0 ? (
+        <Card>
+          <p className="text-gray-500 text-sm text-center py-4">
+            {quotes.length === 0
+              ? 'No quotes yet. Create one to get started.'
+              : `No ${activeTab} quotes.`}
+          </p>
+        </Card>
+      ) : (
+        <div className="space-y-2">
+          {filtered.map((q) => {
+            const totals = computeQuoteTotals(q.quote_line_items, {
+              markup_enabled: q.markup_enabled,
+              markup_percent: q.markup_percent,
+              tax_enabled: q.tax_enabled,
+              tax_percent: q.tax_percent,
+              labor_rate: q.labor_rate,
+              labor_hours: q.labor_hours,
+              flat_fee_enabled: q.flat_fee_enabled,
+              flat_fee: q.flat_fee,
+            })
+            return (
+              <Link key={q.id} href={`/quotes/${q.id}`}>
+                <Card className="hover:shadow-md transition-shadow cursor-pointer">
+                  <div className="flex items-center justify-between gap-4">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 mb-1 flex-wrap">
+                        <span className="text-xs text-gray-400 font-mono">
+                          #{q.quote_number}
+                        </span>
+                        {statusBadge(q.status)}
+                        <span className="text-xs text-gray-500">
+                          {JOB_TYPE_LABEL[q.job_type]}
+                        </span>
+                      </div>
+                      <p className="font-medium text-gray-900 truncate">{q.title}</p>
+                      <p className="text-sm text-gray-500 truncate">
+                        {q.customers?.name ?? 'Unknown customer'}
+                        {q.projects ? ` · ${q.projects.name}` : ''}
+                      </p>
+                    </div>
+                    <div className="text-right shrink-0">
+                      <p className="font-semibold text-gray-900 tabular-nums">
+                        {formatCurrency(totals.grandTotal)}
+                      </p>
+                      <p className="text-xs text-gray-400">
+                        {new Date(q.issued_date + 'T00:00:00').toLocaleDateString(
+                          'en-US',
+                          { month: 'short', day: 'numeric' },
+                        )}
+                      </p>
+                    </div>
+                  </div>
+                </Card>
+              </Link>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/(authenticated)/quotes/new/client.tsx
+++ b/src/app/(authenticated)/quotes/new/client.tsx
@@ -1,0 +1,221 @@
+'use client'
+
+import { useState, useMemo } from 'react'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { Card } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { AlertCircle } from 'lucide-react'
+import type { QuoteJobType } from '@/lib/types/database'
+
+interface CustomerOpt {
+  id: string
+  name: string
+}
+
+interface ProjectOpt {
+  id: string
+  name: string
+  customer_id: string
+}
+
+interface NewQuoteClientProps {
+  customers: CustomerOpt[]
+  projects: ProjectOpt[]
+}
+
+const JOB_TYPES: { value: QuoteJobType; label: string }[] = [
+  { value: 'rough_in', label: 'Rough-In' },
+  { value: 'trim_out', label: 'Trim-Out' },
+  { value: 'service', label: 'Service' },
+]
+
+export function NewQuoteClient({ customers, projects }: NewQuoteClientProps) {
+  const router = useRouter()
+  const [customerId, setCustomerId] = useState('')
+  const [projectId, setProjectId] = useState('')
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+  const [jobType, setJobType] = useState<QuoteJobType>('service')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const filteredProjects = useMemo(
+    () => (customerId ? projects.filter((p) => p.customer_id === customerId) : []),
+    [customerId, projects],
+  )
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+
+    if (!customerId) {
+      setError('Pick a customer.')
+      return
+    }
+    if (!title.trim()) {
+      setError('Title is required.')
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      const res = await fetch('/api/quotes', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          customer_id: customerId,
+          project_id: projectId || null,
+          title: title.trim(),
+          description,
+          job_type: jobType,
+        }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error ?? 'Failed to create quote')
+      router.push(`/quotes/${data.quote.id}`)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create quote')
+      setSubmitting(false)
+    }
+  }
+
+  if (customers.length === 0) {
+    return (
+      <Card>
+        <p className="text-sm text-gray-600 text-center py-6">
+          Add a customer before creating a quote.{' '}
+          <Link href="/customers" className="text-[#68BD45] hover:underline">
+            Go to Customers →
+          </Link>
+        </p>
+      </Card>
+    )
+  }
+
+  return (
+    <Card className="max-w-xl">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label
+            htmlFor="customer"
+            className="block text-sm font-medium text-gray-700 mb-1"
+          >
+            Customer <span className="text-red-500">*</span>
+          </label>
+          <select
+            id="customer"
+            value={customerId}
+            onChange={(e) => {
+              setCustomerId(e.target.value)
+              setProjectId('')
+            }}
+            required
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#68BD45] focus:border-transparent text-sm"
+          >
+            <option value="">Select customer…</option>
+            {customers.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {filteredProjects.length > 0 && (
+          <div>
+            <label
+              htmlFor="project"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              Project (optional)
+            </label>
+            <select
+              id="project"
+              value={projectId}
+              onChange={(e) => setProjectId(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#68BD45] focus:border-transparent text-sm"
+            >
+              <option value="">No project</option>
+              {filteredProjects.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        <Input
+          id="title"
+          label="Title *"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="e.g. New service panel install"
+          required
+        />
+
+        <div>
+          <label
+            htmlFor="description"
+            className="block text-sm font-medium text-gray-700 mb-1"
+          >
+            Description (shows on customer-facing invoice)
+          </label>
+          <textarea
+            id="description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={3}
+            placeholder="Will appear as: Provided material and labor for [your description]"
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#68BD45] focus:border-transparent text-sm"
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="job_type"
+            className="block text-sm font-medium text-gray-700 mb-1"
+          >
+            Job type <span className="text-red-500">*</span>
+          </label>
+          <select
+            id="job_type"
+            value={jobType}
+            onChange={(e) => setJobType(e.target.value as QuoteJobType)}
+            required
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#68BD45] focus:border-transparent text-sm"
+          >
+            {JOB_TYPES.map((j) => (
+              <option key={j.value} value={j.value}>
+                {j.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {error && (
+          <div
+            role="alert"
+            className="flex items-start gap-2 px-3 py-2 rounded-lg bg-red-50 border border-red-200 text-sm text-red-700"
+          >
+            <AlertCircle className="w-4 h-4 mt-0.5 shrink-0" />
+            <span>{error}</span>
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Link href="/quotes">
+            <Button type="button" variant="secondary">
+              Cancel
+            </Button>
+          </Link>
+          <Button type="submit" disabled={submitting}>
+            {submitting ? 'Creating…' : 'Create quote'}
+          </Button>
+        </div>
+      </form>
+    </Card>
+  )
+}

--- a/src/app/(authenticated)/quotes/new/page.tsx
+++ b/src/app/(authenticated)/quotes/new/page.tsx
@@ -1,0 +1,42 @@
+export const dynamic = 'force-dynamic'
+
+import { redirect } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
+import { PageHeader } from '@/components/layout/page-header'
+import { NewQuoteClient } from './client'
+
+export default async function NewQuotePage() {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) redirect('/login')
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single()
+  if (profile?.role !== 'admin') redirect('/dashboard')
+
+  const [{ data: customers }, { data: projects }] = await Promise.all([
+    supabase.from('customers').select('id, name').order('name'),
+    supabase
+      .from('projects')
+      .select('id, name, customer_id, status')
+      .eq('status', 'active')
+      .order('name'),
+  ])
+
+  return (
+    <div>
+      <PageHeader title="New Quote" />
+      <div className="p-4 md:p-6">
+        <NewQuoteClient
+          customers={customers ?? []}
+          projects={projects ?? []}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/app/(authenticated)/quotes/page.tsx
+++ b/src/app/(authenticated)/quotes/page.tsx
@@ -1,0 +1,37 @@
+export const dynamic = 'force-dynamic'
+
+import { redirect } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
+import { PageHeader } from '@/components/layout/page-header'
+import { QuotesClient } from './client'
+
+export default async function QuotesPage() {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) redirect('/login')
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single()
+  if (profile?.role !== 'admin') redirect('/dashboard')
+
+  const { data: quotes } = await supabase
+    .from('quotes')
+    .select(
+      'id, quote_number, title, status, job_type, issued_date, valid_until, customers(name), projects(name), quote_line_items(quantity, unit_price), markup_enabled, markup_percent, tax_enabled, tax_percent, labor_rate, labor_hours, flat_fee_enabled, flat_fee',
+    )
+    .order('created_at', { ascending: false })
+
+  return (
+    <div>
+      <PageHeader title="Quotes" />
+      <div className="p-4 md:p-6">
+        <QuotesClient quotes={(quotes ?? []) as unknown as Parameters<typeof QuotesClient>[0]['quotes']} />
+      </div>
+    </div>
+  )
+}

--- a/src/app/api/quotes/[id]/line-items/[lineId]/route.ts
+++ b/src/app/api/quotes/[id]/line-items/[lineId]/route.ts
@@ -1,0 +1,145 @@
+import { NextResponse } from 'next/server'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { requireAdmin } from '@/lib/api/admin'
+
+function parseNumber(raw: unknown): number | null {
+  if (typeof raw === 'number') {
+    return Number.isFinite(raw) && raw >= 0 ? raw : null
+  }
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim()
+    if (!trimmed) return null
+    const n = Number(trimmed)
+    return Number.isFinite(n) && n >= 0 ? n : null
+  }
+  return null
+}
+
+async function checkQuoteEditable(
+  supabase: SupabaseClient,
+  quoteId: string,
+): Promise<NextResponse | null> {
+  const { data: quote, error } = await supabase
+    .from('quotes')
+    .select('id, status')
+    .eq('id', quoteId)
+    .maybeSingle()
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  if (!quote) {
+    return NextResponse.json({ error: 'Quote not found' }, { status: 404 })
+  }
+  if (quote.status === 'converted') {
+    return NextResponse.json(
+      { error: 'Cannot edit line items on a converted quote' },
+      { status: 409 },
+    )
+  }
+  return null
+}
+
+export async function PATCH(
+  request: Request,
+  context: { params: Promise<{ id: string; lineId: string }> },
+) {
+  const { id: quoteId, lineId } = await context.params
+  if (!quoteId || !lineId) {
+    return NextResponse.json({ error: 'Missing id' }, { status: 400 })
+  }
+
+  const auth = await requireAdmin()
+  if ('error' in auth) return auth.error
+  const { supabase } = auth
+
+  const blocked = await checkQuoteEditable(supabase, quoteId)
+  if (blocked) return blocked
+
+  const body = await request.json().catch(() => null)
+  if (!body || typeof body !== 'object') {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const updates: Record<string, unknown> = {}
+  if ('quantity' in body) {
+    const q = parseNumber(body.quantity)
+    if (q === null) {
+      return NextResponse.json(
+        { error: 'quantity must be a number ≥ 0' },
+        { status: 400 },
+      )
+    }
+    updates.quantity = q
+  }
+  if ('unit_price' in body) {
+    const p = parseNumber(body.unit_price)
+    if (p === null) {
+      return NextResponse.json(
+        { error: 'unit_price must be a number ≥ 0' },
+        { status: 400 },
+      )
+    }
+    updates.unit_price = p
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json({ error: 'No fields to update' }, { status: 400 })
+  }
+
+  const { data, error } = await supabase
+    .from('quote_line_items')
+    .update(updates)
+    .eq('id', lineId)
+    .eq('quote_id', quoteId)
+    .select()
+    .single()
+
+  if (error) {
+    if (error.code === 'PGRST116') {
+      return NextResponse.json({ error: 'Line item not found' }, { status: 404 })
+    }
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  if (!data) {
+    return NextResponse.json({ error: 'Line item not found' }, { status: 404 })
+  }
+
+  return NextResponse.json({ line_item: data })
+}
+
+export async function DELETE(
+  _request: Request,
+  context: { params: Promise<{ id: string; lineId: string }> },
+) {
+  const { id: quoteId, lineId } = await context.params
+  if (!quoteId || !lineId) {
+    return NextResponse.json({ error: 'Missing id' }, { status: 400 })
+  }
+
+  const auth = await requireAdmin()
+  if ('error' in auth) return auth.error
+  const { supabase } = auth
+
+  const blocked = await checkQuoteEditable(supabase, quoteId)
+  if (blocked) return blocked
+
+  const { data, error } = await supabase
+    .from('quote_line_items')
+    .delete()
+    .eq('id', lineId)
+    .eq('quote_id', quoteId)
+    .select('id')
+    .single()
+
+  if (error) {
+    if (error.code === 'PGRST116') {
+      return NextResponse.json({ error: 'Line item not found' }, { status: 404 })
+    }
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  if (!data) {
+    return NextResponse.json({ error: 'Line item not found' }, { status: 404 })
+  }
+
+  return NextResponse.json({ ok: true })
+}

--- a/src/app/api/quotes/[id]/line-items/route.ts
+++ b/src/app/api/quotes/[id]/line-items/route.ts
@@ -96,6 +96,11 @@ export async function POST(
     }
     const cat = material.material_categories as { name: string } | { name: string }[] | null
     const phaseName = Array.isArray(cat) ? cat[0]?.name : cat?.name
+    if (!phaseName) {
+      console.warn(
+        `[line-items] Material ${material.id} (${material.name}) has no resolvable category; falling back to Misc/Other`,
+      )
+    }
     snapshot = {
       material_id: material.id,
       material_name: material.name,
@@ -132,7 +137,11 @@ export async function POST(
     }
   }
 
-  // Compute next sort_order within this quote
+  // Compute next sort_order within this quote.
+  // Race window is real (read-then-insert isn't atomic) but the app is single-
+  // admin; two concurrent line-item adds within the same ms are functionally
+  // unreachable. Worst-case impact is two rows sharing a sort_order and
+  // displaying in arbitrary order — no data corruption.
   const { data: existing } = await supabase
     .from('quote_line_items')
     .select('sort_order')

--- a/src/app/api/quotes/[id]/line-items/route.ts
+++ b/src/app/api/quotes/[id]/line-items/route.ts
@@ -1,0 +1,163 @@
+import { NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/api/admin'
+
+function parseQuantity(raw: unknown): number | null {
+  if (typeof raw === 'number') {
+    return Number.isFinite(raw) && raw >= 0 ? raw : null
+  }
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim()
+    if (!trimmed) return null
+    const n = Number(trimmed)
+    return Number.isFinite(n) && n >= 0 ? n : null
+  }
+  return null
+}
+
+/**
+ * Add a line item to a quote. Two paths:
+ *   1) { material_id, quantity } — server snapshots material name/unit/price/phase
+ *      from the materials + material_categories tables.
+ *   2) { material_name, unit, unit_price, quantity, phase } — custom item; not
+ *      linked back to any material row. Useful for one-off items the user
+ *      doesn't want to add to the main materials list.
+ */
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id: quoteId } = await context.params
+  if (!quoteId) {
+    return NextResponse.json({ error: 'Missing quote id' }, { status: 400 })
+  }
+
+  const auth = await requireAdmin()
+  if ('error' in auth) return auth.error
+  const { supabase } = auth
+
+  const body = await request.json().catch(() => null)
+  if (!body || typeof body !== 'object') {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const quantity = parseQuantity(body.quantity ?? 1)
+  if (quantity === null) {
+    return NextResponse.json(
+      { error: 'quantity must be a number ≥ 0' },
+      { status: 400 },
+    )
+  }
+
+  // Confirm the quote exists and is editable (not converted)
+  const { data: quote, error: quoteError } = await supabase
+    .from('quotes')
+    .select('id, status')
+    .eq('id', quoteId)
+    .maybeSingle()
+  if (quoteError) {
+    return NextResponse.json({ error: quoteError.message }, { status: 500 })
+  }
+  if (!quote) {
+    return NextResponse.json({ error: 'Quote not found' }, { status: 404 })
+  }
+  if (quote.status === 'converted') {
+    return NextResponse.json(
+      { error: 'Cannot edit line items on a converted quote' },
+      { status: 409 },
+    )
+  }
+
+  // Determine snapshot fields
+  let snapshot: {
+    material_id: string | null
+    material_name: string
+    unit: string
+    unit_price: number
+    phase: string
+  }
+
+  if ('material_id' in body && body.material_id) {
+    if (typeof body.material_id !== 'string') {
+      return NextResponse.json(
+        { error: 'material_id must be a string' },
+        { status: 400 },
+      )
+    }
+    const { data: material, error: matError } = await supabase
+      .from('materials')
+      .select('id, name, unit, price, category_id, material_categories(name)')
+      .eq('id', body.material_id)
+      .maybeSingle()
+    if (matError) {
+      return NextResponse.json({ error: matError.message }, { status: 500 })
+    }
+    if (!material) {
+      return NextResponse.json({ error: 'Material not found' }, { status: 404 })
+    }
+    const cat = material.material_categories as { name: string } | { name: string }[] | null
+    const phaseName = Array.isArray(cat) ? cat[0]?.name : cat?.name
+    snapshot = {
+      material_id: material.id,
+      material_name: material.name,
+      unit: material.unit,
+      unit_price: Number(material.price),
+      phase: phaseName ?? 'Misc/Other',
+    }
+  } else {
+    if (typeof body.material_name !== 'string' || !body.material_name.trim()) {
+      return NextResponse.json(
+        { error: 'material_name is required for a custom item' },
+        { status: 400 },
+      )
+    }
+    if (typeof body.unit !== 'string' || !body.unit.trim()) {
+      return NextResponse.json({ error: 'unit is required' }, { status: 400 })
+    }
+    const unitPrice = parseQuantity(body.unit_price)
+    if (unitPrice === null) {
+      return NextResponse.json(
+        { error: 'unit_price must be a number ≥ 0' },
+        { status: 400 },
+      )
+    }
+    if (typeof body.phase !== 'string' || !body.phase.trim()) {
+      return NextResponse.json({ error: 'phase is required' }, { status: 400 })
+    }
+    snapshot = {
+      material_id: null,
+      material_name: body.material_name.trim(),
+      unit: body.unit.trim(),
+      unit_price: unitPrice,
+      phase: body.phase.trim(),
+    }
+  }
+
+  // Compute next sort_order within this quote
+  const { data: existing } = await supabase
+    .from('quote_line_items')
+    .select('sort_order')
+    .eq('quote_id', quoteId)
+    .order('sort_order', { ascending: false })
+    .limit(1)
+  const nextSortOrder = existing && existing.length > 0 ? existing[0].sort_order + 1 : 0
+
+  const { data, error } = await supabase
+    .from('quote_line_items')
+    .insert({
+      quote_id: quoteId,
+      ...snapshot,
+      quantity,
+      sort_order: nextSortOrder,
+    })
+    .select()
+    .single()
+
+  if (error || !data) {
+    return NextResponse.json(
+      { error: error?.message ?? 'Failed to add line item' },
+      { status: 500 },
+    )
+  }
+
+  return NextResponse.json({ line_item: data }, { status: 201 })
+}

--- a/src/app/api/quotes/[id]/route.ts
+++ b/src/app/api/quotes/[id]/route.ts
@@ -1,0 +1,193 @@
+import { NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/api/admin'
+
+const VALID_STATUSES = new Set([
+  'draft',
+  'sent',
+  'accepted',
+  'declined',
+  'expired',
+  'converted',
+])
+const VALID_JOB_TYPES = new Set(['rough_in', 'trim_out', 'service'])
+
+function parseNumber(raw: unknown, opts: { min?: number } = {}): number | null {
+  if (typeof raw === 'number') {
+    return Number.isFinite(raw) && (opts.min === undefined || raw >= opts.min)
+      ? raw
+      : null
+  }
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim()
+    if (!trimmed) return null
+    const n = Number(trimmed)
+    return Number.isFinite(n) && (opts.min === undefined || n >= opts.min)
+      ? n
+      : null
+  }
+  return null
+}
+
+export async function PATCH(
+  request: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id } = await context.params
+  if (!id) return NextResponse.json({ error: 'Missing id' }, { status: 400 })
+
+  const auth = await requireAdmin()
+  if ('error' in auth) return auth.error
+  const { supabase } = auth
+
+  const body = await request.json().catch(() => null)
+  if (!body || typeof body !== 'object') {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const updates: Record<string, unknown> = {}
+
+  // String fields
+  if ('title' in body) {
+    if (typeof body.title !== 'string' || !body.title.trim()) {
+      return NextResponse.json({ error: 'Title must be non-empty' }, { status: 400 })
+    }
+    updates.title = body.title.trim()
+  }
+  if ('description' in body) {
+    if (typeof body.description !== 'string') {
+      return NextResponse.json(
+        { error: 'description must be a string' },
+        { status: 400 },
+      )
+    }
+    updates.description = body.description
+  }
+  if ('notes' in body) {
+    if (body.notes !== null && typeof body.notes !== 'string') {
+      return NextResponse.json({ error: 'notes must be a string' }, { status: 400 })
+    }
+    updates.notes = body.notes
+  }
+  if ('status' in body) {
+    if (typeof body.status !== 'string' || !VALID_STATUSES.has(body.status)) {
+      return NextResponse.json(
+        { error: `status must be one of ${[...VALID_STATUSES].join(', ')}` },
+        { status: 400 },
+      )
+    }
+    updates.status = body.status
+    if (body.status === 'sent') {
+      updates.sent_at = new Date().toISOString()
+    }
+  }
+  if ('job_type' in body) {
+    if (typeof body.job_type !== 'string' || !VALID_JOB_TYPES.has(body.job_type)) {
+      return NextResponse.json(
+        { error: `job_type must be one of ${[...VALID_JOB_TYPES].join(', ')}` },
+        { status: 400 },
+      )
+    }
+    updates.job_type = body.job_type
+  }
+  if ('valid_until' in body) {
+    if (body.valid_until !== null && typeof body.valid_until !== 'string') {
+      return NextResponse.json(
+        { error: 'valid_until must be an ISO date string or null' },
+        { status: 400 },
+      )
+    }
+    updates.valid_until = body.valid_until
+  }
+
+  // Boolean toggles
+  for (const flag of [
+    'markup_enabled',
+    'tax_enabled',
+    'flat_fee_enabled',
+  ] as const) {
+    if (flag in body) {
+      if (typeof body[flag] !== 'boolean') {
+        return NextResponse.json(
+          { error: `${flag} must be a boolean` },
+          { status: 400 },
+        )
+      }
+      updates[flag] = body[flag]
+    }
+  }
+
+  // Numeric fields
+  const numericFields: { key: string; min: number }[] = [
+    { key: 'markup_percent', min: 0 },
+    { key: 'tax_percent', min: 0 },
+    { key: 'labor_rate', min: 0 },
+    { key: 'labor_hours', min: 0 },
+    { key: 'flat_fee', min: 0 },
+  ]
+  for (const { key, min } of numericFields) {
+    if (key in body) {
+      const n = parseNumber(body[key], { min })
+      if (n === null) {
+        return NextResponse.json(
+          { error: `${key} must be a number ≥ ${min}` },
+          { status: 400 },
+        )
+      }
+      updates[key] = n
+    }
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json({ error: 'No fields to update' }, { status: 400 })
+  }
+
+  const { data, error } = await supabase
+    .from('quotes')
+    .update(updates)
+    .eq('id', id)
+    .select()
+    .single()
+
+  if (error) {
+    if (error.code === 'PGRST116') {
+      return NextResponse.json({ error: 'Quote not found' }, { status: 404 })
+    }
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  if (!data) {
+    return NextResponse.json({ error: 'Quote not found' }, { status: 404 })
+  }
+
+  return NextResponse.json({ quote: data })
+}
+
+export async function DELETE(
+  _request: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id } = await context.params
+  if (!id) return NextResponse.json({ error: 'Missing id' }, { status: 400 })
+
+  const auth = await requireAdmin()
+  if ('error' in auth) return auth.error
+  const { supabase } = auth
+
+  const { data, error } = await supabase
+    .from('quotes')
+    .delete()
+    .eq('id', id)
+    .select('id')
+    .single()
+
+  if (error) {
+    if (error.code === 'PGRST116') {
+      return NextResponse.json({ error: 'Quote not found' }, { status: 404 })
+    }
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  if (!data) {
+    return NextResponse.json({ error: 'Quote not found' }, { status: 404 })
+  }
+
+  return NextResponse.json({ ok: true })
+}

--- a/src/app/api/quotes/[id]/route.ts
+++ b/src/app/api/quotes/[id]/route.ts
@@ -11,6 +11,26 @@ const VALID_STATUSES = new Set([
 ])
 const VALID_JOB_TYPES = new Set(['rough_in', 'trim_out', 'service'])
 
+// Once a quote is converted to an invoice, only the status can change (and
+// only by a server-internal flow, not via this PATCH route). Everything else
+// — title, knobs, notes, dates — is locked so historical invoice data stays
+// referentially consistent with the source quote.
+const LOCKED_WHEN_CONVERTED = new Set([
+  'title',
+  'description',
+  'notes',
+  'job_type',
+  'valid_until',
+  'markup_enabled',
+  'markup_percent',
+  'tax_enabled',
+  'tax_percent',
+  'labor_rate',
+  'labor_hours',
+  'flat_fee_enabled',
+  'flat_fee',
+])
+
 function parseNumber(raw: unknown, opts: { min?: number } = {}): number | null {
   if (typeof raw === 'number') {
     return Number.isFinite(raw) && (opts.min === undefined || raw >= opts.min)
@@ -44,9 +64,40 @@ export async function PATCH(
     return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
   }
 
+  // Load current state so we can reason about transitions and locked fields.
+  const { data: current, error: loadError } = await supabase
+    .from('quotes')
+    .select('id, status, sent_at')
+    .eq('id', id)
+    .maybeSingle()
+  if (loadError) {
+    return NextResponse.json({ error: loadError.message }, { status: 500 })
+  }
+  if (!current) {
+    return NextResponse.json({ error: 'Quote not found' }, { status: 404 })
+  }
+
+  // Once converted, lock the quote down. Status cannot leave 'converted'
+  // and editable fields are off-limits.
+  if (current.status === 'converted') {
+    if ('status' in body && body.status !== 'converted') {
+      return NextResponse.json(
+        { error: 'Converted quotes cannot change status' },
+        { status: 409 },
+      )
+    }
+    for (const key of LOCKED_WHEN_CONVERTED) {
+      if (key in body) {
+        return NextResponse.json(
+          { error: `Cannot edit "${key}" on a converted quote` },
+          { status: 409 },
+        )
+      }
+    }
+  }
+
   const updates: Record<string, unknown> = {}
 
-  // String fields
   if ('title' in body) {
     if (typeof body.title !== 'string' || !body.title.trim()) {
       return NextResponse.json({ error: 'Title must be non-empty' }, { status: 400 })
@@ -76,7 +127,8 @@ export async function PATCH(
       )
     }
     updates.status = body.status
-    if (body.status === 'sent') {
+    // Stamp sent_at only on the first transition into 'sent' — never re-stamp.
+    if (body.status === 'sent' && !current.sent_at) {
       updates.sent_at = new Date().toISOString()
     }
   }
@@ -90,16 +142,26 @@ export async function PATCH(
     updates.job_type = body.job_type
   }
   if ('valid_until' in body) {
-    if (body.valid_until !== null && typeof body.valid_until !== 'string') {
-      return NextResponse.json(
-        { error: 'valid_until must be an ISO date string or null' },
-        { status: 400 },
-      )
+    if (body.valid_until === null) {
+      updates.valid_until = null
+    } else {
+      if (typeof body.valid_until !== 'string') {
+        return NextResponse.json(
+          { error: 'valid_until must be an ISO date string or null' },
+          { status: 400 },
+        )
+      }
+      const ts = Date.parse(body.valid_until)
+      if (Number.isNaN(ts)) {
+        return NextResponse.json(
+          { error: 'valid_until must parse as a date (YYYY-MM-DD)' },
+          { status: 400 },
+        )
+      }
+      updates.valid_until = body.valid_until
     }
-    updates.valid_until = body.valid_until
   }
 
-  // Boolean toggles
   for (const flag of [
     'markup_enabled',
     'tax_enabled',
@@ -116,7 +178,6 @@ export async function PATCH(
     }
   }
 
-  // Numeric fields
   const numericFields: { key: string; min: number }[] = [
     { key: 'markup_percent', min: 0 },
     { key: 'tax_percent', min: 0 },

--- a/src/app/api/quotes/route.ts
+++ b/src/app/api/quotes/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/api/admin'
+
+const VALID_JOB_TYPES = new Set(['rough_in', 'trim_out', 'service'])
+
+export async function POST(request: Request) {
+  const auth = await requireAdmin()
+  if ('error' in auth) return auth.error
+  const { supabase, userId } = auth
+
+  const body = await request.json().catch(() => null)
+  if (!body || typeof body !== 'object') {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+  const {
+    customer_id,
+    project_id,
+    title,
+    description,
+    job_type,
+    valid_until,
+    notes,
+  } = body as Record<string, unknown>
+
+  if (typeof customer_id !== 'string' || !customer_id) {
+    return NextResponse.json({ error: 'customer_id is required' }, { status: 400 })
+  }
+  if (typeof title !== 'string' || !title.trim()) {
+    return NextResponse.json({ error: 'Title is required' }, { status: 400 })
+  }
+  if (
+    typeof job_type !== 'string' ||
+    !VALID_JOB_TYPES.has(job_type)
+  ) {
+    return NextResponse.json(
+      { error: `job_type must be one of ${[...VALID_JOB_TYPES].join(', ')}` },
+      { status: 400 },
+    )
+  }
+
+  const insert: Record<string, unknown> = {
+    customer_id,
+    title: title.trim(),
+    description: typeof description === 'string' ? description : '',
+    job_type,
+    project_id:
+      typeof project_id === 'string' && project_id ? project_id : null,
+    valid_until:
+      typeof valid_until === 'string' && valid_until ? valid_until : null,
+    notes: typeof notes === 'string' ? notes : null,
+    created_by: userId,
+  }
+
+  const { data, error } = await supabase
+    .from('quotes')
+    .insert(insert)
+    .select()
+    .single()
+
+  if (error || !data) {
+    return NextResponse.json(
+      { error: error?.message ?? 'Failed to create quote' },
+      { status: 500 },
+    )
+  }
+
+  return NextResponse.json({ quote: data }, { status: 201 })
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
-import { LayoutDashboard, FolderOpen, FileStack, Settings, Clock, BarChart3, Activity, CalendarDays, HelpCircle, LogOut, Receipt, Package } from 'lucide-react'
+import { LayoutDashboard, FolderOpen, FileStack, Settings, Clock, BarChart3, Activity, CalendarDays, HelpCircle, LogOut, Receipt, Package, FileText } from 'lucide-react'
 import { useSupabase } from '@/hooks/use-supabase'
 import { cn } from '@/lib/utils'
 
@@ -16,6 +16,7 @@ const navItems = [
   { href: '/my-time', label: 'My Time', icon: Clock, adminOnly: false },
   { href: '/schedule', label: 'Schedule', icon: CalendarDays, adminOnly: false },
   { href: '/reports', label: 'Reports', icon: BarChart3, adminOnly: true },
+  { href: '/quotes', label: 'Quotes', icon: FileText, adminOnly: true },
   { href: '/invoices', label: 'Invoices', icon: Receipt, adminOnly: true },
   { href: '/materials', label: 'Materials', icon: Package, adminOnly: true },
   { href: '/activity', label: 'Activity', icon: Activity, adminOnly: false },


### PR DESCRIPTION
## Summary

The big M3 slice — Joe can now build a quote end-to-end.

**Pages**
- `/quotes` — status-tabbed list with grand total per row
- `/quotes/new` — minimal create form (customer, project, title, description, job_type)
- `/quotes/[id]` — full builder: header summary with grand total, line items grouped by phase with inline quantity edit + delete + materials picker, pricing knobs (markup/tax/labor/flat-fee toggle+value), itemized totals, "Mark as sent" with confirmation Modal, locked read-only mode when status=converted

**Material picker** — search + categorized active materials → quantity step → server snapshots name/unit/price/phase from the materials + `material_categories` tables so historical quotes survive material edits.

**API** — Admin-only, shared `requireAdmin()`:
- POST `/api/quotes`
- PATCH/DELETE `/api/quotes/[id]` — terminal-status guard (cannot leave 'converted'), locked fields when converted, idempotent `sent_at`, validated `valid_until`
- POST `/api/quotes/[id]/line-items` — material_id snapshot path or custom item; refuses on converted quotes
- PATCH/DELETE `/api/quotes/[id]/line-items/[lineId]`

## Issues

- Closes BlueWaveCreative/Operations#31 — global settings UI
- Closes BlueWaveCreative/Operations#32 — material picker
- Closes BlueWaveCreative/Operations#34 — calc engine totals display
- Closes BlueWaveCreative/Operations#35 — line-item snapshotting
- Closes BlueWaveCreative/Operations#39 — quotes list page
- Refs BlueWaveCreative/Operations#33 — auto-grow deferred (manual + bulk material entry already covered by `/materials` and CSV import)

## Reviews incorporated

- **Critic** P0/P1/P2 — quantity blur race fixed with per-line AbortController + reconcile-on-success; LineItemRow/ToggleNumber/NumberInput re-sync drafts via focus-aware useEffect; PATCH route loads current row first to enforce terminal-status + locked-fields guards; sent_at idempotent; valid_until Date.parse; material picker resets via open-tied useEffect
- **Aesthetic** P0/P1/P2 — Mark-as-sent now uses Modal not native confirm; status badges semantic (declined→danger, expired→default+line-through, converted→info); aria-label on quote card links; read-only banner with Lock icon when converted; ToggleNumber "(not applied)" caption when off; Enter-to-commit on number inputs; LineItemRow stacks on mobile; picker max-h `min(400px,60vh)`; 44px tap targets + visible focus rings; **TotalsRow dynamic-Tailwind bug fixed** (template-string class names that JIT couldn't see); empty-state CTA on quotes list

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run tests/lib` — 45/45
- [x] Vercel preview build for branch tip
- [ ] **Post-merge: apply migration `010_materials_quotes.sql` to Supabase**
- [ ] Manual smoke after migration: create quote, add 5 line items across 2 phases, edit a quantity, toggle markup off/on, change tax %, mark as sent, verify totals match

## Next slice

Quote → Invoice conversion (#38), then we close out M3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)