### PR TITLE
fix(m1): brand sweep + mobile admin nav + schedule overflow + dead links

### DIFF
--- a/src/app/(authenticated)/dashboard/page.tsx
+++ b/src/app/(authenticated)/dashboard/page.tsx
@@ -157,7 +157,7 @@ export default async function DashboardPage() {
         <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
           <Card>
             <div className="flex items-center gap-3">
-              <FolderOpen className="w-8 h-8 text-[#68BD45]" />
+              <FolderOpen className="w-8 h-8 text-[#045815]" />
               <div>
                 <p className="text-2xl font-bold text-gray-900">{projects?.length ?? 0}</p>
                 <p className="text-xs text-gray-600">Active Projects</p>
@@ -180,7 +180,7 @@ export default async function DashboardPage() {
         <div>
           <div className="flex items-center justify-between mb-3">
             <h2 className="text-lg font-semibold text-gray-900">Active Projects</h2>
-            <Link href="/projects" className="text-sm text-[#68BD45] hover:underline">
+            <Link href="/projects" className="text-sm text-[#045815] hover:underline">
               View all
             </Link>
           </div>
@@ -215,7 +215,7 @@ export default async function DashboardPage() {
           <div className="flex items-center justify-between mb-3">
             <h2 className="text-lg font-semibold text-gray-900">Recent Activity</h2>
             {isAdmin && (
-              <Link href="/activity" className="text-sm text-[#68BD45] hover:underline">
+              <Link href="/activity" className="text-sm text-[#045815] hover:underline">
                 View all
               </Link>
             )}

--- a/src/app/(authenticated)/dashboard/today-view.tsx
+++ b/src/app/(authenticated)/dashboard/today-view.tsx
@@ -2,7 +2,7 @@ import { createClient } from '@/lib/supabase/server'
 import { TodayClient, type ScheduleItem, type CompletedJob } from '@/components/dashboard/today-client'
 
 const PROJECT_COLORS = [
-  '#68BD45', '#3B82F6', '#F59E0B', '#EF4444',
+  '#045815', '#3B82F6', '#F59E0B', '#EF4444',
   '#8B5CF6', '#EC4899', '#14B8A6', '#F97316',
 ]
 

--- a/src/app/(authenticated)/help/page.tsx
+++ b/src/app/(authenticated)/help/page.tsx
@@ -15,8 +15,8 @@ function Section({ icon: Icon, title, children }: { icon: React.ElementType; tit
   return (
     <Card className="mb-4">
       <div className="flex items-start gap-3">
-        <div className="p-2 bg-[#68BD45]/10 rounded-lg flex-shrink-0">
-          <Icon className="w-5 h-5 text-[#68BD45]" />
+        <div className="p-2 bg-[#045815]/10 rounded-lg flex-shrink-0">
+          <Icon className="w-5 h-5 text-[#045815]" />
         </div>
         <div className="flex-1">
           <h2 className="text-lg font-semibold text-gray-900 mb-2">{title}</h2>
@@ -30,7 +30,7 @@ function Section({ icon: Icon, title, children }: { icon: React.ElementType; tit
 function Step({ number, children }: { number: number; children: React.ReactNode }) {
   return (
     <div className="flex items-start gap-2">
-      <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[#68BD45] text-white text-xs font-bold flex items-center justify-center mt-0.5">
+      <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[#045815] text-white text-xs font-bold flex items-center justify-center mt-0.5">
         {number}
       </span>
       <p>{children}</p>

--- a/src/app/(authenticated)/invoices/[id]/client.tsx
+++ b/src/app/(authenticated)/invoices/[id]/client.tsx
@@ -129,7 +129,7 @@ export function InvoiceDetailClient({ invoice }: InvoiceDetailClientProps) {
         <div className="text-sm text-gray-500 mb-4">
           Issued {formatDate(invoice.issued_date)}
           {notifiedAt && (
-            <span className="ml-3 text-[#68BD45]">
+            <span className="ml-3 text-[#045815]">
               · Notified {new Date(notifiedAt).toLocaleDateString()}
             </span>
           )}

--- a/src/app/(authenticated)/invoices/client.tsx
+++ b/src/app/(authenticated)/invoices/client.tsx
@@ -48,7 +48,7 @@ export function InvoicesClient({ invoices }: InvoicesClientProps) {
 
   return (
     <div className="space-y-4 max-w-4xl">
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
         <div className="flex gap-2 flex-wrap">
           {STATUS_TABS.map(tab => (
             <button
@@ -56,7 +56,7 @@ export function InvoicesClient({ invoices }: InvoicesClientProps) {
               onClick={() => setActiveTab(tab.value)}
               className={`px-4 py-1.5 rounded-full text-sm font-medium transition-colors ${
                 activeTab === tab.value
-                  ? 'bg-[#68BD45] text-white'
+                  ? 'bg-[#045815] text-white'
                   : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
               }`}
             >
@@ -66,7 +66,7 @@ export function InvoicesClient({ invoices }: InvoicesClientProps) {
         </div>
         <Link
           href="/invoices/new"
-          className="inline-flex items-center px-4 py-2 text-sm font-medium rounded-xl bg-[#68BD45] text-white hover:bg-[#5aa83c] transition-colors shadow-sm hover:shadow-md"
+          className="inline-flex items-center px-4 py-2 text-sm font-medium rounded-xl bg-[#045815] text-white hover:bg-[#023510] transition-colors shadow-sm hover:shadow-md focus:outline-none focus:ring-2 focus:ring-[#045815] focus:ring-offset-2"
         >
           <Plus className="w-4 h-4 mr-2" /> New Invoice
         </Link>
@@ -74,7 +74,21 @@ export function InvoicesClient({ invoices }: InvoicesClientProps) {
 
       {filtered.length === 0 ? (
         <Card>
-          <p className="text-gray-500 text-sm text-center py-4">No invoices yet.</p>
+          <div className="text-center py-6 space-y-3">
+            <p className="text-gray-500 text-sm">
+              {invoices.length === 0
+                ? 'No invoices yet. Create one to bill a customer.'
+                : `No ${activeTab} invoices.`}
+            </p>
+            {invoices.length === 0 && (
+              <Link
+                href="/invoices/new"
+                className="inline-flex items-center px-4 py-2 text-sm font-medium rounded-xl bg-[#045815] text-white hover:bg-[#023510] focus:outline-none focus:ring-2 focus:ring-[#045815] focus:ring-offset-2"
+              >
+                <Plus className="w-4 h-4 mr-1" /> New invoice
+              </Link>
+            )}
+          </div>
         </Card>
       ) : (
         <div className="space-y-2">

--- a/src/app/(authenticated)/invoices/new/client.tsx
+++ b/src/app/(authenticated)/invoices/new/client.tsx
@@ -131,7 +131,7 @@ export function NewInvoiceClient({ customers, projects, presets }: NewInvoiceCli
             <select
               value={customerId}
               onChange={e => { setCustomerId(e.target.value); setProjectId('') }}
-              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#68BD45]"
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#045815]"
             >
               <option value="">Select customer...</option>
               {customers.map(c => <option key={c.id} value={c.id}>{c.name}</option>)}
@@ -143,7 +143,7 @@ export function NewInvoiceClient({ customers, projects, presets }: NewInvoiceCli
             <select
               value={projectId}
               onChange={e => setProjectId(e.target.value)}
-              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#68BD45]"
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#045815]"
             >
               <option value="">No project</option>
               {filteredProjects.map(p => <option key={p.id} value={p.id}>{p.name}</option>)}
@@ -172,7 +172,7 @@ export function NewInvoiceClient({ customers, projects, presets }: NewInvoiceCli
               value={notes}
               onChange={e => setNotes(e.target.value)}
               rows={2}
-              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#68BD45] placeholder:text-gray-400"
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#045815] placeholder:text-gray-400"
               placeholder="Any notes for the customer..."
             />
           </div>
@@ -187,7 +187,7 @@ export function NewInvoiceClient({ customers, projects, presets }: NewInvoiceCli
               <div className="flex gap-2">
                 <select
                   onChange={e => { applyPreset(idx, e.target.value); e.target.value = '' }}
-                  className="flex-1 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#68BD45]"
+                  className="flex-1 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#045815]"
                   defaultValue=""
                 >
                   <option value="">Pick a preset or type below...</option>
@@ -233,7 +233,7 @@ export function NewInvoiceClient({ customers, projects, presets }: NewInvoiceCli
 
         <button
           onClick={addLineItem}
-          className="mt-3 flex items-center gap-1 text-sm text-[#68BD45] hover:text-green-700 font-medium"
+          className="mt-3 flex items-center gap-1 text-sm text-[#045815] hover:text-green-700 font-medium"
         >
           <Plus className="w-4 h-4" /> Add line item
         </button>
@@ -253,7 +253,7 @@ export function NewInvoiceClient({ customers, projects, presets }: NewInvoiceCli
                 placeholder="0.00"
                 min="0"
                 step="0.01"
-                className="w-24 border border-gray-300 rounded px-2 py-1 text-sm text-right focus:outline-none focus:ring-1 focus:ring-[#68BD45]"
+                className="w-24 border border-gray-300 rounded px-2 py-1 text-sm text-right focus:outline-none focus:ring-1 focus:ring-[#045815]"
               />
             </div>
           </div>

--- a/src/app/(authenticated)/materials/client.tsx
+++ b/src/app/(authenticated)/materials/client.tsx
@@ -41,7 +41,7 @@ function formatCurrency(amount: number) {
 }
 
 const ICON_BUTTON_BASE =
-  'inline-flex items-center justify-center w-11 h-11 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-[#68BD45]'
+  'inline-flex items-center justify-center w-11 h-11 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-[#045815]'
 
 export function MaterialsClient({ categories, materials }: MaterialsClientProps) {
   const router = useRouter()
@@ -222,7 +222,7 @@ export function MaterialsClient({ categories, materials }: MaterialsClientProps)
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             aria-label="Search materials"
-            className="w-full pl-9 pr-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#68BD45] focus:border-transparent text-sm"
+            className="w-full pl-9 pr-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#045815] focus:border-transparent text-sm"
           />
         </div>
         <p className="text-sm text-gray-500" aria-live="polite">
@@ -352,7 +352,7 @@ export function MaterialsClient({ categories, materials }: MaterialsClientProps)
                   onChange={(e) =>
                     setForm({ ...form, unit: e.target.value as MaterialUnit })
                   }
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#68BD45] focus:border-transparent text-sm"
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#045815] focus:border-transparent text-sm"
                 >
                   {UNIT_OPTIONS.map((u) => (
                     <option key={u} value={u}>
@@ -385,7 +385,7 @@ export function MaterialsClient({ categories, materials }: MaterialsClientProps)
                 onChange={(e) =>
                   setForm({ ...form, category_id: e.target.value })
                 }
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#68BD45] focus:border-transparent text-sm"
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#045815] focus:border-transparent text-sm"
               >
                 {categories.map((c) => (
                   <option key={c.id} value={c.id}>

--- a/src/app/(authenticated)/materials/import-modal.tsx
+++ b/src/app/(authenticated)/materials/import-modal.tsx
@@ -230,7 +230,7 @@ export function ImportModal({
             <label
               htmlFor="csv-file"
               aria-describedby="csv-help"
-              className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-xl bg-[#68BD45] text-white hover:bg-[#5aa83c] cursor-pointer focus-within:ring-2 focus-within:ring-[#68BD45] focus-within:ring-offset-2"
+              className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-xl bg-[#045815] text-white hover:bg-[#023510] cursor-pointer focus-within:ring-2 focus-within:ring-[#045815] focus-within:ring-offset-2"
             >
               <FileText className="w-4 h-4" />
               Choose CSV file

--- a/src/app/(authenticated)/projects/[id]/client.tsx
+++ b/src/app/(authenticated)/projects/[id]/client.tsx
@@ -257,7 +257,7 @@ export function ProjectDetailClient({
                           await supabase.from('tasks').update({ status: newStatus }).eq('id', task.id)
                           window.location.reload()
                         }}
-                        className="w-5 h-5 rounded border-gray-300 text-[#68BD45] focus:ring-[#68BD45]"
+                        className="w-5 h-5 rounded border-gray-300 text-[#045815] focus:ring-[#045815]"
                         aria-label={`Mark "${task.title}" as ${task.status === 'complete' ? 'incomplete' : 'complete'}`}
                       />
                       <span className={task.status === 'complete' ? 'line-through text-gray-500' : 'text-gray-700'}>
@@ -293,12 +293,12 @@ export function ProjectDetailClient({
                 <p className="font-medium text-gray-900">{customer.name}</p>
                 {customer.email && (
                   <p className="text-sm text-gray-600">
-                    <a href={`mailto:${customer.email}`} className="text-[#68BD45] hover:underline">{customer.email}</a>
+                    <a href={`mailto:${customer.email}`} className="text-[#045815] hover:underline">{customer.email}</a>
                   </p>
                 )}
                 {customer.phone && (
                   <p className="text-sm text-gray-600">
-                    <a href={`tel:${customer.phone}`} className="text-[#68BD45] hover:underline">{customer.phone}</a>
+                    <a href={`tel:${customer.phone}`} className="text-[#045815] hover:underline">{customer.phone}</a>
                   </p>
                 )}
                 {customer.address && <p className="text-sm text-gray-500">{customer.address}</p>}
@@ -354,7 +354,7 @@ export function ProjectDetailClient({
           <h2 className="text-lg font-semibold text-gray-900">Blueprints</h2>
           <a
             href={`/projects/${project.id}/plans`}
-            className="text-sm text-[#68BD45] hover:underline"
+            className="text-sm text-[#045815] hover:underline"
           >
             {hasPlans ? 'View Plans' : 'Upload Blueprint'}
           </a>
@@ -364,7 +364,7 @@ export function ProjectDetailClient({
             <p className="text-gray-500 text-sm">No blueprints uploaded yet.</p>
             <a
               href={`/projects/${project.id}/plans`}
-              className="text-[#68BD45] text-sm hover:underline mt-1 inline-block"
+              className="text-[#045815] text-sm hover:underline mt-1 inline-block"
             >
               Upload one now
             </a>

--- a/src/app/(authenticated)/projects/[id]/plans/page.tsx
+++ b/src/app/(authenticated)/projects/[id]/plans/page.tsx
@@ -73,7 +73,7 @@ export default async function PlansPage({
                 <Card hoverable className="mb-3">
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-3">
-                      <FileImage className="w-8 h-8 text-[#68BD45]" />
+                      <FileImage className="w-8 h-8 text-[#045815]" />
                       <div>
                         <h3 className="font-medium text-gray-900">{plan.name}</h3>
                         <p className="text-xs text-gray-500">

--- a/src/app/(authenticated)/quotes/[id]/client.tsx
+++ b/src/app/(authenticated)/quotes/[id]/client.tsx
@@ -254,7 +254,7 @@ export function QuoteBuilderClient({
       <div className="flex items-center justify-between flex-wrap gap-3">
         <Link
           href="/quotes"
-          className="inline-flex items-center text-sm text-gray-600 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-[#68BD45] rounded"
+          className="inline-flex items-center text-sm text-gray-600 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-[#045815] rounded"
         >
           <ArrowLeft className="w-4 h-4 mr-1" /> All quotes
         </Link>
@@ -638,7 +638,7 @@ function LineItemRow({
         }}
         disabled={readOnly}
         aria-label={`Quantity for ${item.material_name}`}
-        className="w-20 px-2 py-1 border border-gray-300 rounded text-sm text-right tabular-nums focus:outline-none focus:ring-2 focus:ring-[#68BD45] focus:border-transparent disabled:bg-gray-50 disabled:text-gray-500"
+        className="w-20 px-2 py-1 border border-gray-300 rounded text-sm text-right tabular-nums focus:outline-none focus:ring-2 focus:ring-[#045815] focus:border-transparent disabled:bg-gray-50 disabled:text-gray-500"
       />
       <p className="text-sm font-semibold text-gray-900 tabular-nums w-24 text-right shrink-0">
         {formatCurrency(Number(item.unit_price) * Number(item.quantity))}
@@ -647,7 +647,7 @@ function LineItemRow({
         <button
           type="button"
           onClick={onDelete}
-          className="inline-flex items-center justify-center w-11 h-11 rounded-lg text-gray-500 hover:bg-red-50 hover:text-red-600 transition-colors focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-[#68BD45]"
+          className="inline-flex items-center justify-center w-11 h-11 rounded-lg text-gray-500 hover:bg-red-50 hover:text-red-600 transition-colors focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-[#045815]"
           aria-label={`Remove ${item.material_name}`}
         >
           <Trash2 className="w-4 h-4" />
@@ -698,7 +698,7 @@ function ToggleNumber({
           checked={enabled}
           disabled={disabled}
           onChange={(e) => onChange(e.target.checked, value)}
-          className="rounded border-gray-300 text-[#68BD45] focus:ring-[#68BD45]"
+          className="rounded border-gray-300 text-[#045815] focus:ring-[#045815]"
         />
         <span>{label}</span>
         {!enabled && (
@@ -726,7 +726,7 @@ function ToggleNumber({
           }}
           disabled={disabled || !enabled}
           aria-label={label}
-          className="flex-1 px-2 py-1 border border-gray-300 rounded text-sm text-right tabular-nums focus:outline-none focus:ring-2 focus:ring-[#68BD45] focus:border-transparent disabled:bg-gray-50 disabled:text-gray-400"
+          className="flex-1 px-2 py-1 border border-gray-300 rounded text-sm text-right tabular-nums focus:outline-none focus:ring-2 focus:ring-[#045815] focus:border-transparent disabled:bg-gray-50 disabled:text-gray-400"
         />
         {suffix && <span className="text-gray-500">{suffix}</span>}
       </div>
@@ -789,7 +789,7 @@ function NumberInput({
           }}
           disabled={disabled}
           aria-label={label}
-          className="flex-1 px-2 py-1 border border-gray-300 rounded text-sm text-right tabular-nums focus:outline-none focus:ring-2 focus:ring-[#68BD45] focus:border-transparent disabled:bg-gray-50 disabled:text-gray-400"
+          className="flex-1 px-2 py-1 border border-gray-300 rounded text-sm text-right tabular-nums focus:outline-none focus:ring-2 focus:ring-[#045815] focus:border-transparent disabled:bg-gray-50 disabled:text-gray-400"
         />
         {suffix && <span className="text-gray-500">{suffix}</span>}
       </div>

--- a/src/app/(authenticated)/quotes/[id]/material-picker.tsx
+++ b/src/app/(authenticated)/quotes/[id]/material-picker.tsx
@@ -126,7 +126,7 @@ export function MaterialPickerModal({
               value={quantity}
               onChange={(e) => setQuantity(e.target.value)}
               autoFocus
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#68BD45] focus:border-transparent text-sm tabular-nums"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#045815] focus:border-transparent text-sm tabular-nums"
             />
           </div>
           {error && (
@@ -166,7 +166,7 @@ export function MaterialPickerModal({
               onChange={(e) => setSearch(e.target.value)}
               autoFocus
               aria-label="Search materials"
-              className="w-full pl-9 pr-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#68BD45] focus:border-transparent text-sm"
+              className="w-full pl-9 pr-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#045815] focus:border-transparent text-sm"
             />
           </div>
 
@@ -174,7 +174,7 @@ export function MaterialPickerModal({
             {categories.length === 0 || materials.length === 0 ? (
               <p className="text-sm text-gray-500 text-center py-8">
                 No materials available. Add materials in the{' '}
-                <a href="/materials" className="text-[#68BD45] hover:underline">
+                <a href="/materials" className="text-[#045815] hover:underline">
                   Materials
                 </a>{' '}
                 page first.
@@ -195,7 +195,7 @@ export function MaterialPickerModal({
                             <button
                               type="button"
                               onClick={() => setSelected(m)}
-                              className="w-full flex items-center gap-3 px-3 py-3 min-h-[44px] text-left hover:bg-gray-50 focus:outline-none focus:bg-gray-100 focus:ring-2 focus:ring-[#68BD45] focus:ring-inset"
+                              className="w-full flex items-center gap-3 px-3 py-3 min-h-[44px] text-left hover:bg-gray-50 focus:outline-none focus:bg-gray-100 focus:ring-2 focus:ring-[#045815] focus:ring-inset"
                             >
                               <div className="flex-1 min-w-0">
                                 <p className="text-sm text-gray-900 truncate">

--- a/src/app/(authenticated)/quotes/client.tsx
+++ b/src/app/(authenticated)/quotes/client.tsx
@@ -91,7 +91,7 @@ export function QuotesClient({ quotes }: QuotesClientProps) {
               onClick={() => setActiveTab(tab.value)}
               className={`px-4 py-1.5 rounded-full text-sm font-medium transition-colors ${
                 activeTab === tab.value
-                  ? 'bg-[#68BD45] text-white'
+                  ? 'bg-[#045815] text-white'
                   : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
               }`}
             >
@@ -101,7 +101,7 @@ export function QuotesClient({ quotes }: QuotesClientProps) {
         </div>
         <Link
           href="/quotes/new"
-          className="inline-flex items-center px-4 py-2 text-sm font-medium rounded-xl bg-[#68BD45] text-white hover:bg-[#5aa83c] transition-colors shadow-sm hover:shadow-md focus:outline-none focus:ring-2 focus:ring-[#68BD45] focus:ring-offset-2"
+          className="inline-flex items-center px-4 py-2 text-sm font-medium rounded-xl bg-[#045815] text-white hover:bg-[#023510] transition-colors shadow-sm hover:shadow-md focus:outline-none focus:ring-2 focus:ring-[#045815] focus:ring-offset-2"
         >
           <Plus className="w-4 h-4 mr-2" /> New Quote
         </Link>
@@ -118,7 +118,7 @@ export function QuotesClient({ quotes }: QuotesClientProps) {
             {quotes.length === 0 && (
               <Link
                 href="/quotes/new"
-                className="inline-flex items-center px-4 py-2 text-sm font-medium rounded-xl bg-[#68BD45] text-white hover:bg-[#5aa83c] focus:outline-none focus:ring-2 focus:ring-[#68BD45] focus:ring-offset-2"
+                className="inline-flex items-center px-4 py-2 text-sm font-medium rounded-xl bg-[#045815] text-white hover:bg-[#023510] focus:outline-none focus:ring-2 focus:ring-[#045815] focus:ring-offset-2"
               >
                 <Plus className="w-4 h-4 mr-1" /> New quote
               </Link>
@@ -143,7 +143,7 @@ export function QuotesClient({ quotes }: QuotesClientProps) {
                 key={q.id}
                 href={`/quotes/${q.id}`}
                 aria-label={`Open quote #${q.quote_number}: ${q.title}`}
-                className="block focus:outline-none focus:ring-2 focus:ring-[#68BD45] focus:ring-offset-2 rounded-xl"
+                className="block focus:outline-none focus:ring-2 focus:ring-[#045815] focus:ring-offset-2 rounded-xl"
               >
                 <Card className="hover:shadow-md transition-shadow cursor-pointer">
                   <div className="flex items-center justify-between gap-4">

--- a/src/app/(authenticated)/quotes/new/client.tsx
+++ b/src/app/(authenticated)/quotes/new/client.tsx
@@ -85,10 +85,15 @@ export function NewQuoteClient({ customers, projects }: NewQuoteClientProps) {
     return (
       <Card>
         <p className="text-sm text-gray-600 text-center py-6">
-          Add a customer before creating a quote.{' '}
-          <Link href="/customers" className="text-[#68BD45] hover:underline">
-            Go to Customers →
-          </Link>
+          You don&rsquo;t have any customers yet. Customers are created during
+          project setup —{' '}
+          <Link
+            href="/projects"
+            className="text-[#045815] font-medium hover:underline"
+          >
+            start a project
+          </Link>{' '}
+          to add one.
         </p>
       </Card>
     )
@@ -112,7 +117,7 @@ export function NewQuoteClient({ customers, projects }: NewQuoteClientProps) {
               setProjectId('')
             }}
             required
-            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#68BD45] focus:border-transparent text-sm"
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#045815] focus:border-transparent text-sm"
           >
             <option value="">Select customer…</option>
             {customers.map((c) => (
@@ -135,7 +140,7 @@ export function NewQuoteClient({ customers, projects }: NewQuoteClientProps) {
               id="project"
               value={projectId}
               onChange={(e) => setProjectId(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#68BD45] focus:border-transparent text-sm"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#045815] focus:border-transparent text-sm"
             >
               <option value="">No project</option>
               {filteredProjects.map((p) => (
@@ -169,7 +174,7 @@ export function NewQuoteClient({ customers, projects }: NewQuoteClientProps) {
             onChange={(e) => setDescription(e.target.value)}
             rows={3}
             placeholder="Will appear as: Provided material and labor for [your description]"
-            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#68BD45] focus:border-transparent text-sm"
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#045815] focus:border-transparent text-sm"
           />
         </div>
 
@@ -185,7 +190,7 @@ export function NewQuoteClient({ customers, projects }: NewQuoteClientProps) {
             value={jobType}
             onChange={(e) => setJobType(e.target.value as QuoteJobType)}
             required
-            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#68BD45] focus:border-transparent text-sm"
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#045815] focus:border-transparent text-sm"
           >
             {JOB_TYPES.map((j) => (
               <option key={j.value} value={j.value}>

--- a/src/app/(authenticated)/schedule/client.tsx
+++ b/src/app/(authenticated)/schedule/client.tsx
@@ -35,7 +35,7 @@ interface ScheduleBoardProps {
 }
 
 const PROJECT_COLORS = [
-  '#68BD45', // brand green
+  '#045815', // brand green
   '#3B82F6', // blue
   '#F59E0B', // amber
   '#EF4444', // red
@@ -207,7 +207,7 @@ export function ScheduleBoard({ crew, projects, initialEntries, rangeStart, isAd
         key={date}
         className={cn(
           'relative px-1 py-1 border-t border-gray-100 text-center min-w-[90px]',
-          isToday && 'bg-[#68BD45]/5',
+          isToday && 'bg-[#045815]/5',
           weekend && 'bg-gray-50/50',
           extraClassName
         )}
@@ -217,7 +217,7 @@ export function ScheduleBoard({ crew, projects, initialEntries, rangeStart, isAd
           onClick={() => canEdit && setActiveCell(isActive ? null : { userId, date })}
           disabled={saving || !canEdit}
           className={cn(
-            'w-full rounded-md px-1.5 py-1 text-xs font-medium transition-colors min-h-[32px] focus:outline-none focus:ring-2 focus:ring-[#68BD45]/50',
+            'w-full rounded-md px-1.5 py-1 text-xs font-medium transition-colors min-h-[32px] focus:outline-none focus:ring-2 focus:ring-[#045815]/50',
             entry
               ? 'bg-gray-50 hover:bg-gray-100 text-gray-700'
               : 'hover:bg-gray-50 text-gray-500 hover:text-gray-600 group'
@@ -270,7 +270,7 @@ export function ScheduleBoard({ crew, projects, initialEntries, rangeStart, isAd
                   onClick={() => handleAssign(userId, date, p.id)}
                   className={cn(
                     'w-full text-left px-3 py-2 text-xs hover:bg-gray-50 transition-colors flex items-center gap-2',
-                    isSelected && 'bg-[#68BD45]/5 font-medium'
+                    isSelected && 'bg-[#045815]/5 font-medium'
                   )}
                   role="option"
                   aria-selected={isSelected}
@@ -298,7 +298,7 @@ export function ScheduleBoard({ crew, projects, initialEntries, rangeStart, isAd
   const legendProjects = projects.filter((p) => usedProjectIds.has(p.id))
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 min-w-0">
       {legendProjects.length > 0 && (
         <div className="flex flex-wrap gap-3 text-xs text-gray-600">
           {legendProjects.map((p) => (
@@ -343,7 +343,7 @@ export function ScheduleBoard({ crew, projects, initialEntries, rangeStart, isAd
                   key={date}
                   className={cn(
                     'px-1 py-2 text-xs font-medium text-center whitespace-nowrap min-w-[90px]',
-                    date === today && 'bg-[#68BD45]/5',
+                    date === today && 'bg-[#045815]/5',
                     isWeekend(date) ? 'text-gray-500' : 'text-gray-600'
                   )}
                 >
@@ -356,7 +356,7 @@ export function ScheduleBoard({ crew, projects, initialEntries, rangeStart, isAd
                   className={cn(
                     'px-1 py-2 text-xs font-medium text-center whitespace-nowrap min-w-[90px]',
                     i === 0 && 'border-l border-gray-200',
-                    date === today && 'bg-[#68BD45]/5',
+                    date === today && 'bg-[#045815]/5',
                     isWeekend(date) ? 'text-gray-500' : 'text-gray-600'
                   )}
                 >

--- a/src/app/(authenticated)/schedule/client.tsx
+++ b/src/app/(authenticated)/schedule/client.tsx
@@ -207,7 +207,7 @@ export function ScheduleBoard({ crew, projects, initialEntries, rangeStart, isAd
         key={date}
         className={cn(
           'relative px-1 py-1 border-t border-gray-100 text-center min-w-[90px]',
-          isToday && 'bg-[#045815]/5',
+          isToday && 'bg-[#045815]/10 ring-1 ring-[#045815]/20',
           weekend && 'bg-gray-50/50',
           extraClassName
         )}
@@ -270,7 +270,7 @@ export function ScheduleBoard({ crew, projects, initialEntries, rangeStart, isAd
                   onClick={() => handleAssign(userId, date, p.id)}
                   className={cn(
                     'w-full text-left px-3 py-2 text-xs hover:bg-gray-50 transition-colors flex items-center gap-2',
-                    isSelected && 'bg-[#045815]/5 font-medium'
+                    isSelected && 'bg-[#045815]/10 ring-1 ring-[#045815]/20 font-medium'
                   )}
                   role="option"
                   aria-selected={isSelected}
@@ -343,7 +343,7 @@ export function ScheduleBoard({ crew, projects, initialEntries, rangeStart, isAd
                   key={date}
                   className={cn(
                     'px-1 py-2 text-xs font-medium text-center whitespace-nowrap min-w-[90px]',
-                    date === today && 'bg-[#045815]/5',
+                    date === today && 'bg-[#045815]/10 ring-1 ring-[#045815]/20',
                     isWeekend(date) ? 'text-gray-500' : 'text-gray-600'
                   )}
                 >
@@ -356,7 +356,7 @@ export function ScheduleBoard({ crew, projects, initialEntries, rangeStart, isAd
                   className={cn(
                     'px-1 py-2 text-xs font-medium text-center whitespace-nowrap min-w-[90px]',
                     i === 0 && 'border-l border-gray-200',
-                    date === today && 'bg-[#045815]/5',
+                    date === today && 'bg-[#045815]/10 ring-1 ring-[#045815]/20',
                     isWeekend(date) ? 'text-gray-500' : 'text-gray-600'
                   )}
                 >

--- a/src/app/(authenticated)/settings/client.tsx
+++ b/src/app/(authenticated)/settings/client.tsx
@@ -62,7 +62,7 @@ function CustomerPortalRow({
           onClick={handleToggle}
           disabled={toggling}
           className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors ${
-            active ? 'bg-[#68BD45]' : 'bg-gray-300'
+            active ? 'bg-[#045815]' : 'bg-gray-300'
           }`}
           role="switch"
           aria-checked={active}
@@ -82,7 +82,7 @@ function CustomerPortalRow({
           {customer.email && (
             <button
               onClick={() => onSendEmail(customer.id)}
-              className="text-xs px-3 py-1.5 rounded-full border border-[#68BD45] text-[#68BD45] hover:bg-green-50"
+              className="text-xs px-3 py-1.5 rounded-full border border-[#045815] text-[#045815] hover:bg-green-50"
             >
               Send Email
             </button>
@@ -171,21 +171,21 @@ function LineItemPresetsSection({
           value={newName}
           onChange={e => setNewName(e.target.value)}
           placeholder="Preset name (e.g. Labor)"
-          className="flex-1 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#68BD45] placeholder:text-gray-400"
+          className="flex-1 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#045815] placeholder:text-gray-400"
         />
         <input
           type="number"
           value={newPrice}
           onChange={e => setNewPrice(e.target.value)}
           placeholder="Default price"
-          className="w-32 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#68BD45] placeholder:text-gray-400"
+          className="w-32 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#045815] placeholder:text-gray-400"
           min="0"
           step="0.01"
         />
         <button
           onClick={addPreset}
           disabled={saving || !newName.trim()}
-          className="px-4 py-2 bg-[#68BD45] text-white rounded-lg text-sm font-medium disabled:opacity-50 hover:bg-green-600 transition-colors"
+          className="px-4 py-2 bg-[#045815] text-white rounded-lg text-sm font-medium disabled:opacity-50 hover:bg-green-600 transition-colors"
         >
           Add
         </button>
@@ -253,7 +253,7 @@ export function SettingsClient({ users, notificationPreferences, userId, custome
                   <button
                     onClick={() => toggleUserStatus(u.id, u.status)}
                     className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-                      u.status === 'active' ? 'bg-[#68BD45]' : 'bg-gray-300'
+                      u.status === 'active' ? 'bg-[#045815]' : 'bg-gray-300'
                     }`}
                     role="switch"
                     aria-checked={u.status === 'active'}

--- a/src/app/portal/[token]/client.tsx
+++ b/src/app/portal/[token]/client.tsx
@@ -58,7 +58,7 @@ export function PortalClient({ customerName, portalToken, projects, invoices }: 
       <header className="bg-[#32373C] text-white px-4 py-4">
         <div className="max-w-xl mx-auto flex items-center justify-between">
           <img src="/brand/energi-logo-horizontal.png" alt="Energi Electric" className="h-8" />
-          <a href="tel:9106192000" className="text-sm text-[#68BD45] font-medium">(910) 619-2000</a>
+          <a href="tel:9106192000" className="text-sm text-[#045815] font-medium">(910) 619-2000</a>
         </div>
       </header>
 
@@ -184,7 +184,7 @@ export function PortalClient({ customerName, portalToken, projects, invoices }: 
                       href={`/api/portal/invoice/${invoice.id}/pdf?token=${portalToken}`}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="mt-3 inline-block text-sm text-[#68BD45] hover:text-green-700 font-medium"
+                      className="mt-3 inline-block text-sm text-[#045815] hover:text-green-700 font-medium"
                     >
                       Download PDF →
                     </a>

--- a/src/components/activity/activity-feed.tsx
+++ b/src/components/activity/activity-feed.tsx
@@ -16,7 +16,7 @@ interface ActivityFeedProps {
 }
 
 const typeConfig = {
-  note: { icon: StickyNote, color: 'text-[#68BD45]', bg: 'bg-[#68BD45]/10' },
+  note: { icon: StickyNote, color: 'text-[#045815]', bg: 'bg-[#045815]/10' },
   photo: { icon: Camera, color: 'text-purple-500', bg: 'bg-purple-100' },
   time_entry: { icon: Clock, color: 'text-green-500', bg: 'bg-green-100' },
   phase_change: { icon: CheckCircle, color: 'text-orange-500', bg: 'bg-orange-100' },

--- a/src/components/annotation/drawing-tools.tsx
+++ b/src/components/annotation/drawing-tools.tsx
@@ -49,7 +49,7 @@ export function DrawingTools({
           className={cn(
             'p-3 rounded-md transition-colors',
             activeMode === mode
-              ? 'bg-[#68BD45]/10 text-[#68BD45]'
+              ? 'bg-[#045815]/10 text-[#045815]'
               : 'text-gray-500 hover:bg-gray-100'
           )}
         >

--- a/src/components/annotation/drawing-tools.tsx
+++ b/src/components/annotation/drawing-tools.tsx
@@ -49,7 +49,7 @@ export function DrawingTools({
           className={cn(
             'p-3 rounded-md transition-colors',
             activeMode === mode
-              ? 'bg-[#045815]/10 text-[#045815]'
+              ? 'bg-[#045815]/15 text-[#023510]'
               : 'text-gray-500 hover:bg-gray-100'
           )}
         >

--- a/src/components/annotation/plan-upload.tsx
+++ b/src/components/annotation/plan-upload.tsx
@@ -105,12 +105,12 @@ export function PlanUpload({ projectId, userId }: PlanUploadProps) {
           if (file) handleFile(file)
         }}
         className={`relative border-2 border-dashed rounded-lg p-8 text-center transition-colors ${
-          dragOver ? 'border-[#68BD45] bg-[#68BD45]/5' : 'border-gray-300'
+          dragOver ? 'border-[#045815] bg-[#045815]/5' : 'border-gray-300'
         }`}
       >
         {selectedFile ? (
           <div className="flex items-center justify-center gap-3">
-            <FileImage className="w-8 h-8 text-[#68BD45]" />
+            <FileImage className="w-8 h-8 text-[#045815]" />
             <div className="text-left">
               <p className="font-medium">{selectedFile.name}</p>
               <p className="text-sm text-gray-500">

--- a/src/components/annotation/symbol-toolbar.tsx
+++ b/src/components/annotation/symbol-toolbar.tsx
@@ -28,7 +28,7 @@ export function SymbolToolbar({ onSelectSymbol, activeColor, onColorChange }: Sy
             className={cn(
               'px-2 py-1 text-xs rounded-md font-medium transition-colors',
               activeCategory === cat.name
-                ? 'bg-[#045815]/10 text-[#045815]'
+                ? 'bg-[#045815]/15 text-[#023510]'
                 : 'text-gray-500 hover:bg-gray-100'
             )}
           >

--- a/src/components/annotation/symbol-toolbar.tsx
+++ b/src/components/annotation/symbol-toolbar.tsx
@@ -28,7 +28,7 @@ export function SymbolToolbar({ onSelectSymbol, activeColor, onColorChange }: Sy
             className={cn(
               'px-2 py-1 text-xs rounded-md font-medium transition-colors',
               activeCategory === cat.name
-                ? 'bg-[#68BD45]/10 text-[#68BD45]'
+                ? 'bg-[#045815]/10 text-[#045815]'
                 : 'text-gray-500 hover:bg-gray-100'
             )}
           >
@@ -43,7 +43,7 @@ export function SymbolToolbar({ onSelectSymbol, activeColor, onColorChange }: Sy
           <button
             key={symbol.name}
             onClick={() => onSelectSymbol(symbol)}
-            className="flex flex-col items-center gap-1 p-2 rounded-lg border border-gray-200 hover:border-[#68BD45]/30 hover:bg-[#68BD45]/5 transition-colors"
+            className="flex flex-col items-center gap-1 p-2 rounded-lg border border-gray-200 hover:border-[#045815]/30 hover:bg-[#045815]/5 transition-colors"
             title={symbol.label}
             aria-label={symbol.label}
           >
@@ -77,7 +77,7 @@ export function SymbolToolbar({ onSelectSymbol, activeColor, onColorChange }: Sy
               aria-label={`Wire color: ${wc.name}`}
               className={cn(
                 'w-6 h-6 rounded-full border-2 transition-transform',
-                activeColor === wc.color ? 'border-[#68BD45] scale-110' : 'border-gray-300'
+                activeColor === wc.color ? 'border-[#045815] scale-110' : 'border-gray-300'
               )}
               style={{ backgroundColor: wc.color }}
             />

--- a/src/components/dashboard/add-job-modal.tsx
+++ b/src/components/dashboard/add-job-modal.tsx
@@ -114,7 +114,7 @@ export function AddJobModal({ open, onClose, userId, excludeProjectIds }: AddJob
               id="project-select"
               value={selectedProjectId}
               onChange={(e) => setSelectedProjectId(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-[#68BD45] focus:border-transparent"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-[#045815] focus:border-transparent"
             >
               <option value="">Select a project...</option>
               {projects.map((p) => (
@@ -136,7 +136,7 @@ export function AddJobModal({ open, onClose, userId, excludeProjectIds }: AddJob
             value={phaseName}
             onChange={(e) => setPhaseName(e.target.value)}
             placeholder="e.g., Emergency Service Call"
-            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-[#68BD45] focus:border-transparent placeholder:text-gray-400"
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-[#045815] focus:border-transparent placeholder:text-gray-400"
           />
         </div>
 

--- a/src/components/dashboard/job-card.tsx
+++ b/src/components/dashboard/job-card.tsx
@@ -100,7 +100,7 @@ export function JobCard({
               </p>
             </div>
           </div>
-          <Check className="w-5 h-5 text-[#68BD45]" />
+          <Check className="w-5 h-5 text-[#045815]" />
         </div>
       </div>
     )
@@ -109,10 +109,10 @@ export function JobCard({
   // --- ACTIVE STATE (clocked in) ---
   if (isActiveJob) {
     return (
-      <div className="bg-[#f0faf0] rounded-lg border-2 border-[#68BD45]/30 shadow-sm p-4">
+      <div className="bg-[#f0faf0] rounded-lg border-2 border-[#045815]/30 shadow-sm p-4">
         {/* Timer banner */}
-        <div className="flex items-center justify-between mb-3 px-3 py-2 bg-[#68BD45]/10 rounded-lg">
-          <span className="text-xl font-bold text-[#68BD45] tabular-nums">
+        <div className="flex items-center justify-between mb-3 px-3 py-2 bg-[#045815]/10 rounded-lg">
+          <span className="text-xl font-bold text-[#045815] tabular-nums">
             {formatElapsed(elapsed)}
           </span>
           <button
@@ -133,13 +133,13 @@ export function JobCard({
             {project.address && (
               <p className="text-xs text-gray-500">{project.address}</p>
             )}
-            <p className="text-xs text-[#68BD45] font-medium">{activePhase?.name} · clocked in</p>
+            <p className="text-xs text-[#045815] font-medium">{activePhase?.name} · clocked in</p>
           </div>
         </div>
 
         {/* Task checklist */}
         {localTasks.length > 0 && (
-          <div className="border-t border-[#68BD45]/20 pt-3 mb-3">
+          <div className="border-t border-[#045815]/20 pt-3 mb-3">
             {localTasks.map((task) => (
               <label
                 key={task.id}
@@ -149,7 +149,7 @@ export function JobCard({
                   type="checkbox"
                   checked={task.status === 'complete'}
                   onChange={() => handleTaskToggle(task.id, task.status)}
-                  className="w-6 h-6 rounded border-gray-300 text-[#68BD45] focus:ring-[#68BD45]"
+                  className="w-6 h-6 rounded border-gray-300 text-[#045815] focus:ring-[#045815]"
                 />
                 <span
                   className={cn(
@@ -172,7 +172,7 @@ export function JobCard({
         )}
 
         {localTasks.length === 0 && activePhase && (
-          <div className="border-t border-[#68BD45]/20 pt-3 mb-3">
+          <div className="border-t border-[#045815]/20 pt-3 mb-3">
             <p className="text-xs text-gray-400 mb-2">No tasks yet</p>
             <QuickTaskInput
               phaseId={activePhase.id}
@@ -267,7 +267,7 @@ export function JobCard({
           <button
             type="button"
             onClick={onClockIn}
-            className="flex items-center gap-1.5 px-4 py-3 text-sm font-semibold bg-[#68BD45] text-white rounded-lg hover:bg-[#5aa83c] transition-colors"
+            className="flex items-center gap-1.5 px-4 py-3 text-sm font-semibold bg-[#045815] text-white rounded-lg hover:bg-[#023510] transition-colors"
           >
             ▶ Clock In
           </button>
@@ -294,7 +294,7 @@ export function JobCard({
                 type="checkbox"
                 checked={task.status === 'complete'}
                 onChange={() => handleTaskToggle(task.id, task.status)}
-                className="w-6 h-6 rounded border-gray-300 text-[#68BD45] focus:ring-[#68BD45]"
+                className="w-6 h-6 rounded border-gray-300 text-[#045815] focus:ring-[#045815]"
               />
               <span
                 className={cn(

--- a/src/components/dashboard/quick-note-input.tsx
+++ b/src/components/dashboard/quick-note-input.tsx
@@ -48,7 +48,7 @@ export function QuickNoteForm({ projectId, userId, onDone }: {
         autoFocus
         disabled={saving}
         aria-label="Quick note"
-        className="flex-1 px-3 py-1.5 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#68BD45] focus:border-transparent placeholder:text-gray-400"
+        className="flex-1 px-3 py-1.5 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#045815] focus:border-transparent placeholder:text-gray-400"
         onKeyDown={(e) => {
           if (e.key === 'Escape') onDone()
         }}
@@ -56,7 +56,7 @@ export function QuickNoteForm({ projectId, userId, onDone }: {
       <button
         type="submit"
         disabled={!content.trim() || saving}
-        className="p-1.5 bg-[#68BD45] text-white rounded-lg hover:bg-[#5aa83c] disabled:opacity-50 disabled:cursor-not-allowed"
+        className="p-1.5 bg-[#045815] text-white rounded-lg hover:bg-[#023510] disabled:opacity-50 disabled:cursor-not-allowed"
       >
         <Send className="w-4 h-4" />
       </button>

--- a/src/components/dashboard/quick-task-input.tsx
+++ b/src/components/dashboard/quick-task-input.tsx
@@ -46,7 +46,7 @@ export function QuickTaskInput({ phaseId, userId, onTaskAdded }: QuickTaskInputP
       <button
         type="button"
         onClick={() => setIsOpen(true)}
-        className="flex items-center gap-2 py-2 text-sm text-[#68BD45] hover:text-[#5aa83c] transition-colors w-full"
+        className="flex items-center gap-2 py-2 text-sm text-[#045815] hover:text-[#023510] transition-colors w-full"
       >
         <Plus className="w-4 h-4" />
         <span>Add task...</span>
@@ -64,7 +64,7 @@ export function QuickTaskInput({ phaseId, userId, onTaskAdded }: QuickTaskInputP
         autoFocus
         disabled={saving}
         aria-label="Task title"
-        className="flex-1 px-3 py-1.5 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#68BD45] focus:border-transparent placeholder:text-gray-400"
+        className="flex-1 px-3 py-1.5 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#045815] focus:border-transparent placeholder:text-gray-400"
         onKeyDown={(e) => {
           if (e.key === 'Escape') {
             setTitle('')
@@ -75,7 +75,7 @@ export function QuickTaskInput({ phaseId, userId, onTaskAdded }: QuickTaskInputP
       <button
         type="submit"
         disabled={!title.trim() || saving}
-        className="px-3 py-1.5 text-sm bg-[#68BD45] text-white rounded-lg hover:bg-[#5aa83c] disabled:opacity-50 disabled:cursor-not-allowed"
+        className="px-3 py-1.5 text-sm bg-[#045815] text-white rounded-lg hover:bg-[#023510] disabled:opacity-50 disabled:cursor-not-allowed"
       >
         Add
       </button>

--- a/src/components/dashboard/today-client.tsx
+++ b/src/components/dashboard/today-client.tsx
@@ -33,7 +33,7 @@ interface TodayClientProps {
 }
 
 const PROJECT_COLORS = [
-  '#68BD45', '#3B82F6', '#F59E0B', '#EF4444',
+  '#045815', '#3B82F6', '#F59E0B', '#EF4444',
   '#8B5CF6', '#EC4899', '#14B8A6', '#F97316',
 ]
 
@@ -129,7 +129,7 @@ export function TodayClient({ user, schedule, totalMinutes, completedJobs }: Tod
         </div>
         <div className={`px-3 py-1 rounded-full text-sm font-semibold ${
           totalMinutes > 0 || isRunning
-            ? 'bg-[#68BD45] text-white'
+            ? 'bg-[#045815] text-white'
             : 'bg-gray-200 text-gray-500'
         }`}>
           {formatDuration(totalMinutes + (isRunning ? Math.round(elapsed / 60) : 0))} today
@@ -202,7 +202,7 @@ export function TodayClient({ user, schedule, totalMinutes, completedJobs }: Tod
           <p className="text-gray-600 text-sm">No jobs scheduled for today.</p>
           <p className="text-gray-500 text-xs mt-1">
             Check with your admin or{' '}
-            <a href="/schedule" className="text-[#68BD45] underline hover:text-[#5aa83c]">view the full schedule</a>.
+            <a href="/schedule" className="text-[#045815] underline hover:text-[#023510]">view the full schedule</a>.
           </p>
         </div>
       )}
@@ -211,7 +211,7 @@ export function TodayClient({ user, schedule, totalMinutes, completedJobs }: Tod
       <button
         type="button"
         onClick={() => setShowAddJobModal(true)}
-        className="w-full flex items-center justify-center gap-2 py-3 text-sm text-[#68BD45] border border-dashed border-[#68BD45]/50 rounded-lg hover:bg-[#68BD45]/5 transition-colors focus:outline-none focus:ring-2 focus:ring-[#68BD45]/50"
+        className="w-full flex items-center justify-center gap-2 py-3 text-sm text-[#045815] border border-dashed border-[#045815]/50 rounded-lg hover:bg-[#045815]/5 transition-colors focus:outline-none focus:ring-2 focus:ring-[#045815]/50"
       >
         <Plus className="w-4 h-4" aria-hidden="true" />
         Add unscheduled job

--- a/src/components/dashboard/weather-card.tsx
+++ b/src/components/dashboard/weather-card.tsx
@@ -28,7 +28,7 @@ export function WeatherCard({ forecast }: WeatherCardProps) {
   return (
     <Card>
       <div className="flex items-center gap-2 mb-3">
-        <Sun className="w-4 h-4 text-[#68BD45]" />
+        <Sun className="w-4 h-4 text-[#045815]" />
         <h3 className="text-sm font-semibold text-gray-900">Wilmington Weather</h3>
       </div>
       <div className="grid grid-cols-3 gap-3">

--- a/src/components/field/action-bar.tsx
+++ b/src/components/field/action-bar.tsx
@@ -68,7 +68,7 @@ export function ActionBar({
         {/* Add Note */}
         <button
           onClick={onAddNote}
-          className="flex flex-col items-center gap-1 px-3 py-2 rounded-lg text-xs font-medium text-[#68BD45]"
+          className="flex flex-col items-center gap-1 px-3 py-2 rounded-lg text-xs font-medium text-[#045815]"
         >
           <StickyNote className="w-6 h-6" />
           Note
@@ -77,7 +77,7 @@ export function ActionBar({
         {/* Take Photo */}
         <button
           onClick={onTakePhoto}
-          className="flex flex-col items-center gap-1 px-3 py-2 rounded-lg text-xs font-medium text-[#68BD45]"
+          className="flex flex-col items-center gap-1 px-3 py-2 rounded-lg text-xs font-medium text-[#045815]"
         >
           <Camera className="w-6 h-6" />
           Photo
@@ -86,7 +86,7 @@ export function ActionBar({
         {/* Log Time */}
         <button
           onClick={onLogTime}
-          className="flex flex-col items-center gap-1 px-3 py-2 rounded-lg text-xs font-medium text-[#68BD45]"
+          className="flex flex-col items-center gap-1 px-3 py-2 rounded-lg text-xs font-medium text-[#045815]"
         >
           <Clock className="w-6 h-6" />
           Log Time
@@ -96,7 +96,7 @@ export function ActionBar({
         {hasPlans && (
           <button
             onClick={onViewPlans}
-            className="flex flex-col items-center gap-1 px-3 py-2 rounded-lg text-xs font-medium text-[#68BD45]"
+            className="flex flex-col items-center gap-1 px-3 py-2 rounded-lg text-xs font-medium text-[#045815]"
           >
             <Map className="w-6 h-6" />
             Plans

--- a/src/components/field/expense-form.tsx
+++ b/src/components/field/expense-form.tsx
@@ -111,7 +111,7 @@ export function ExpenseForm({ projectId, userId, onSuccess }: ExpenseFormProps) 
           id="expense-category"
           value={category}
           onChange={(e) => setCategory(e.target.value)}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#68BD45] focus:border-transparent text-sm"
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#045815] focus:border-transparent text-sm"
         >
           {CATEGORIES.map((cat) => (
             <option key={cat.value} value={cat.value}>{cat.label}</option>

--- a/src/components/field/inspection-form.tsx
+++ b/src/components/field/inspection-form.tsx
@@ -78,7 +78,7 @@ export function InspectionForm({ projectId, userId, onSuccess }: InspectionFormP
           id="inspection-type"
           value={type}
           onChange={(e) => setType(e.target.value)}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#68BD45] focus:border-transparent text-sm"
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#045815] focus:border-transparent text-sm"
         >
           {TYPES.map((t) => (
             <option key={t.value} value={t.value}>{t.label}</option>
@@ -94,7 +94,7 @@ export function InspectionForm({ projectId, userId, onSuccess }: InspectionFormP
           id="inspection-status"
           value={status}
           onChange={(e) => setStatus(e.target.value)}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#68BD45] focus:border-transparent text-sm"
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#045815] focus:border-transparent text-sm"
         >
           {STATUSES.map((s) => (
             <option key={s.value} value={s.value}>{s.label}</option>
@@ -120,7 +120,7 @@ export function InspectionForm({ projectId, userId, onSuccess }: InspectionFormP
           onChange={(e) => setNotes(e.target.value)}
           placeholder="Any details about this inspection..."
           rows={3}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#68BD45] focus:border-transparent text-sm resize-none placeholder:text-gray-400"
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#045815] focus:border-transparent text-sm resize-none placeholder:text-gray-400"
         />
       </div>
 

--- a/src/components/field/manual-time-form.tsx
+++ b/src/components/field/manual-time-form.tsx
@@ -92,7 +92,7 @@ export function ManualTimeForm({ projectId, onSubmit, phases }: ManualTimeFormPr
             id="phase"
             value={phaseId}
             onChange={(e) => setPhaseId(e.target.value)}
-            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#68BD45] focus:border-transparent text-sm"
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#045815] focus:border-transparent text-sm"
           >
             <option value="">General</option>
             {phases.map((p) => (

--- a/src/components/field/note-form.tsx
+++ b/src/components/field/note-form.tsx
@@ -34,13 +34,13 @@ export function NoteForm({ onSubmit, placeholder = 'Add a note...' }: NoteFormPr
         placeholder={placeholder}
         aria-label="Note content"
         rows={2}
-        className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#68BD45] focus:border-transparent text-sm resize-none placeholder:text-gray-400"
+        className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#045815] focus:border-transparent text-sm resize-none placeholder:text-gray-400"
       />
       <button
         type="submit"
         disabled={!content.trim() || saving}
         aria-label="Add Note"
-        className="self-end p-2 bg-[#68BD45] text-white rounded-lg hover:bg-[#5aa83c] disabled:opacity-50 disabled:cursor-not-allowed"
+        className="self-end p-2 bg-[#045815] text-white rounded-lg hover:bg-[#023510] disabled:opacity-50 disabled:cursor-not-allowed"
       >
         <Send className="w-4 h-4" />
       </button>

--- a/src/components/field/photo-gallery.tsx
+++ b/src/components/field/photo-gallery.tsx
@@ -128,7 +128,7 @@ export function PhotoGallery({ photos, onDelete, onDeleteMultiple }: PhotoGaller
             {selectMode && (
               <div className="absolute top-1 left-1">
                 {selectedIds.has(photo.id) ? (
-                  <CheckSquare className="w-6 h-6 text-[#68BD45] drop-shadow-md" />
+                  <CheckSquare className="w-6 h-6 text-[#045815] drop-shadow-md" />
                 ) : (
                   <Square className="w-6 h-6 text-white drop-shadow-md" />
                 )}

--- a/src/components/layout/bottom-nav.tsx
+++ b/src/components/layout/bottom-nav.tsx
@@ -43,11 +43,11 @@ export function BottomNav({ isAdmin }: BottomNavProps) {
               className={cn(
                 'flex flex-col items-center gap-1 px-3 py-2 rounded-lg text-xs font-medium transition-colors min-w-[60px]',
                 isActive
-                  ? 'text-[#68BD45]'
+                  ? 'text-[#045815]'
                   : 'text-gray-400 hover:text-gray-600'
               )}
             >
-              <item.icon className={cn('w-6 h-6', isActive && 'text-[#68BD45]')} />
+              <item.icon className={cn('w-6 h-6', isActive && 'text-[#045815]')} />
               {item.label}
             </Link>
           )

--- a/src/components/layout/mobile-menu-drawer.tsx
+++ b/src/components/layout/mobile-menu-drawer.tsx
@@ -1,0 +1,137 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { usePathname, useRouter } from 'next/navigation'
+import { Menu, X, LogOut } from 'lucide-react'
+import { useSupabase } from '@/hooks/use-supabase'
+import { cn } from '@/lib/utils'
+import { visibleNavItems } from './nav-items'
+
+interface MobileMenuDrawerProps {
+  isAdmin: boolean
+}
+
+/**
+ * Mobile-only hamburger + slide-in drawer that mirrors the desktop sidebar.
+ * Solves the problem where admins on phones could not reach Quotes / Materials /
+ * Invoices / Settings / Reports / Activity / Templates from the bottom nav.
+ *
+ * Hamburger button is fixed top-right; visible only below md.
+ */
+export function MobileMenuDrawer({ isAdmin }: MobileMenuDrawerProps) {
+  const pathname = usePathname()
+  const router = useRouter()
+  const supabase = useSupabase()
+  const [open, setOpen] = useState(false)
+
+  const items = visibleNavItems(isAdmin)
+
+  // Close on route change so the drawer doesn't linger after navigation
+  useEffect(() => {
+    setOpen(false)
+  }, [pathname])
+
+  // Lock body scroll while open + close on Esc
+  useEffect(() => {
+    if (!open) return
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.body.style.overflow = previousOverflow
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  async function handleLogout() {
+    setOpen(false)
+    await supabase.auth.signOut()
+    router.push('/login')
+    router.refresh()
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-label="Open menu"
+        aria-expanded={open}
+        className="md:hidden fixed top-3 left-3 z-40 inline-flex items-center justify-center w-11 h-11 rounded-lg bg-white border border-gray-200 shadow-sm text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-[#045815]"
+      >
+        <Menu className="w-5 h-5" />
+      </button>
+
+      {open && (
+        <div
+          className="md:hidden fixed inset-0 z-50 bg-black/50"
+          onClick={() => setOpen(false)}
+          aria-hidden="true"
+        />
+      )}
+
+      <aside
+        className={cn(
+          'md:hidden fixed top-0 left-0 z-50 h-full w-72 bg-[#32373C] flex flex-col transition-transform duration-200 ease-out',
+          open ? 'translate-x-0' : '-translate-x-full',
+        )}
+        role="dialog"
+        aria-label="Main menu"
+        aria-hidden={!open}
+      >
+        <div className="flex items-center justify-between p-4 bg-white border-b border-white/10">
+          <img
+            src="/brand/energi-logo-horizontal.png"
+            alt="Energi Electric"
+            className="h-7"
+          />
+          <button
+            type="button"
+            onClick={() => setOpen(false)}
+            aria-label="Close menu"
+            className="inline-flex items-center justify-center w-11 h-11 -mr-2 rounded-lg text-gray-600 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-[#045815]"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <nav aria-label="Main navigation" className="flex-1 p-3 space-y-1 overflow-y-auto">
+          {items.map((item) => {
+            const isActive = pathname.startsWith(item.href)
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                aria-current={isActive ? 'page' : undefined}
+                className={cn(
+                  'flex items-center gap-3 px-3 py-3 rounded-lg text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-white/40',
+                  isActive
+                    ? 'bg-[#045815] text-white shadow-sm'
+                    : 'text-gray-300 hover:bg-white/5 hover:text-white',
+                )}
+              >
+                <item.icon className="w-5 h-5" />
+                {item.label}
+              </Link>
+            )
+          })}
+        </nav>
+
+        <div className="p-3 border-t border-white/10">
+          <button
+            type="button"
+            onClick={handleLogout}
+            className="flex items-center gap-3 px-3 py-3 rounded-lg text-sm font-medium text-gray-300 hover:bg-white/5 hover:text-white transition-colors w-full focus:outline-none focus:ring-2 focus:ring-white/40"
+          >
+            <LogOut className="w-5 h-5" />
+            Log Out
+          </button>
+        </div>
+      </aside>
+    </>
+  )
+}

--- a/src/components/layout/mobile-menu-drawer.tsx
+++ b/src/components/layout/mobile-menu-drawer.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
 import { Menu, X, LogOut } from 'lucide-react'
@@ -17,13 +17,16 @@ interface MobileMenuDrawerProps {
  * Solves the problem where admins on phones could not reach Quotes / Materials /
  * Invoices / Settings / Reports / Activity / Templates from the bottom nav.
  *
- * Hamburger button is fixed top-right; visible only below md.
+ * Hamburger is fixed top-left; visible only below md.
  */
 export function MobileMenuDrawer({ isAdmin }: MobileMenuDrawerProps) {
   const pathname = usePathname()
   const router = useRouter()
   const supabase = useSupabase()
   const [open, setOpen] = useState(false)
+  const hamburgerRef = useRef<HTMLButtonElement>(null)
+  const closeBtnRef = useRef<HTMLButtonElement>(null)
+  const drawerRef = useRef<HTMLElement>(null)
 
   const items = visibleNavItems(isAdmin)
 
@@ -32,18 +35,65 @@ export function MobileMenuDrawer({ isAdmin }: MobileMenuDrawerProps) {
     setOpen(false)
   }, [pathname])
 
-  // Lock body scroll while open + close on Esc
+  // Open: lock body scroll, focus the close button, trap Tab inside drawer
   useEffect(() => {
     if (!open) return
     const previousOverflow = document.body.style.overflow
     document.body.style.overflow = 'hidden'
-    function onKey(e: KeyboardEvent) {
-      if (e.key === 'Escape') setOpen(false)
+
+    // Initial focus on close button
+    closeBtnRef.current?.focus()
+
+    function focusableElements(): HTMLElement[] {
+      const root = drawerRef.current
+      if (!root) return []
+      return Array.from(
+        root.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ),
+      ).filter((el) => !el.hasAttribute('inert') && el.offsetParent !== null)
     }
+
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        setOpen(false)
+        return
+      }
+      if (e.key !== 'Tab') return
+      const elements = focusableElements()
+      if (elements.length === 0) return
+      const first = elements[0]
+      const last = elements[elements.length - 1]
+      const active = document.activeElement as HTMLElement | null
+      if (e.shiftKey) {
+        if (active === first || !drawerRef.current?.contains(active)) {
+          e.preventDefault()
+          last.focus()
+        }
+      } else {
+        if (active === last) {
+          e.preventDefault()
+          first.focus()
+        }
+      }
+    }
+
     document.addEventListener('keydown', onKey)
     return () => {
       document.body.style.overflow = previousOverflow
       document.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  // Restore focus to hamburger when the drawer closes
+  useEffect(() => {
+    if (!open && hamburgerRef.current && document.activeElement !== hamburgerRef.current) {
+      // Only restore if focus was inside the drawer (don't yank focus away
+      // from a content link the user just clicked)
+      const active = document.activeElement
+      const wasInsideDrawer = drawerRef.current?.contains(active as Node)
+      if (wasInsideDrawer) hamburgerRef.current.focus()
     }
   }, [open])
 
@@ -57,11 +107,13 @@ export function MobileMenuDrawer({ isAdmin }: MobileMenuDrawerProps) {
   return (
     <>
       <button
+        ref={hamburgerRef}
         type="button"
         onClick={() => setOpen(true)}
         aria-label="Open menu"
         aria-expanded={open}
-        className="md:hidden fixed top-3 left-3 z-40 inline-flex items-center justify-center w-11 h-11 rounded-lg bg-white border border-gray-200 shadow-sm text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-[#045815]"
+        aria-controls="mobile-menu-drawer"
+        className="md:hidden fixed top-3 left-3 z-40 inline-flex items-center justify-center w-11 h-11 rounded-lg bg-[#32373C] text-white shadow-md hover:bg-[#3f454c] focus:outline-none focus:ring-2 focus:ring-[#045815] focus:ring-offset-2"
       >
         <Menu className="w-5 h-5" />
       </button>
@@ -75,21 +127,26 @@ export function MobileMenuDrawer({ isAdmin }: MobileMenuDrawerProps) {
       )}
 
       <aside
+        ref={drawerRef}
+        id="mobile-menu-drawer"
+        // @ts-expect-error - inert is valid HTML5 but not in @types/react yet on this version
+        inert={open ? undefined : ''}
         className={cn(
-          'md:hidden fixed top-0 left-0 z-50 h-full w-72 bg-[#32373C] flex flex-col transition-transform duration-200 ease-out',
+          'md:hidden fixed top-0 left-0 z-50 h-full w-[85vw] max-w-xs bg-[#32373C] flex flex-col transition-transform duration-200 ease-out',
           open ? 'translate-x-0' : '-translate-x-full',
         )}
         role="dialog"
+        aria-modal="true"
         aria-label="Main menu"
-        aria-hidden={!open}
       >
-        <div className="flex items-center justify-between p-4 bg-white border-b border-white/10">
+        <div className="flex items-center justify-between p-4 bg-white border-b border-gray-200">
           <img
             src="/brand/energi-logo-horizontal.png"
             alt="Energi Electric"
             className="h-7"
           />
           <button
+            ref={closeBtnRef}
             type="button"
             onClick={() => setOpen(false)}
             aria-label="Close menu"
@@ -108,10 +165,10 @@ export function MobileMenuDrawer({ isAdmin }: MobileMenuDrawerProps) {
                 href={item.href}
                 aria-current={isActive ? 'page' : undefined}
                 className={cn(
-                  'flex items-center gap-3 px-3 py-3 rounded-lg text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-white/40',
+                  'flex items-center gap-3 px-3 py-3 rounded-lg text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-white/70',
                   isActive
                     ? 'bg-[#045815] text-white shadow-sm'
-                    : 'text-gray-300 hover:bg-white/5 hover:text-white',
+                    : 'text-gray-300 hover:bg-white/10 hover:text-white',
                 )}
               >
                 <item.icon className="w-5 h-5" />
@@ -125,7 +182,7 @@ export function MobileMenuDrawer({ isAdmin }: MobileMenuDrawerProps) {
           <button
             type="button"
             onClick={handleLogout}
-            className="flex items-center gap-3 px-3 py-3 rounded-lg text-sm font-medium text-gray-300 hover:bg-white/5 hover:text-white transition-colors w-full focus:outline-none focus:ring-2 focus:ring-white/40"
+            className="flex items-center gap-3 px-3 py-3 rounded-lg text-sm font-medium text-gray-300 hover:bg-white/10 hover:text-white transition-colors w-full focus:outline-none focus:ring-2 focus:ring-white/70"
           >
             <LogOut className="w-5 h-5" />
             Log Out

--- a/src/components/layout/nav-items.ts
+++ b/src/components/layout/nav-items.ts
@@ -1,0 +1,41 @@
+import {
+  LayoutDashboard,
+  FolderOpen,
+  FileStack,
+  Settings,
+  Clock,
+  BarChart3,
+  Activity,
+  CalendarDays,
+  HelpCircle,
+  Receipt,
+  Package,
+  FileText,
+  type LucideIcon,
+} from 'lucide-react'
+
+export interface NavItem {
+  href: string
+  label: string
+  icon: LucideIcon
+  adminOnly: boolean
+}
+
+export const NAV_ITEMS: NavItem[] = [
+  { href: '/dashboard', label: 'Dashboard', icon: LayoutDashboard, adminOnly: false },
+  { href: '/projects', label: 'Projects', icon: FolderOpen, adminOnly: false },
+  { href: '/my-time', label: 'My Time', icon: Clock, adminOnly: false },
+  { href: '/schedule', label: 'Schedule', icon: CalendarDays, adminOnly: false },
+  { href: '/reports', label: 'Reports', icon: BarChart3, adminOnly: true },
+  { href: '/quotes', label: 'Quotes', icon: FileText, adminOnly: true },
+  { href: '/invoices', label: 'Invoices', icon: Receipt, adminOnly: true },
+  { href: '/materials', label: 'Materials', icon: Package, adminOnly: true },
+  { href: '/activity', label: 'Activity', icon: Activity, adminOnly: false },
+  { href: '/templates', label: 'Templates', icon: FileStack, adminOnly: true },
+  { href: '/settings', label: 'Settings', icon: Settings, adminOnly: true },
+  { href: '/help', label: 'Help', icon: HelpCircle, adminOnly: false },
+]
+
+export function visibleNavItems(isAdmin: boolean): NavItem[] {
+  return NAV_ITEMS.filter((i) => !i.adminOnly || isAdmin)
+}

--- a/src/components/layout/nav-shell.tsx
+++ b/src/components/layout/nav-shell.tsx
@@ -18,7 +18,7 @@ export function NavShell({ isAdmin, children }: NavShellProps) {
       </a>
       <Sidebar isAdmin={isAdmin} />
       <MobileMenuDrawer isAdmin={isAdmin} />
-      <main id="main-content" className="flex-1 min-w-0 pb-20 md:pb-0">
+      <main id="main-content" className="flex-1 min-w-0 pt-14 md:pt-0 pb-20 md:pb-0">
         {children}
       </main>
       <BottomNav isAdmin={isAdmin} />

--- a/src/components/layout/nav-shell.tsx
+++ b/src/components/layout/nav-shell.tsx
@@ -3,6 +3,7 @@
 import { type ReactNode } from 'react'
 import { Sidebar } from './sidebar'
 import { BottomNav } from './bottom-nav'
+import { MobileMenuDrawer } from './mobile-menu-drawer'
 
 interface NavShellProps {
   isAdmin: boolean
@@ -12,11 +13,12 @@ interface NavShellProps {
 export function NavShell({ isAdmin, children }: NavShellProps) {
   return (
     <div className="flex min-h-screen bg-gray-50">
-      <a href="#main-content" className="sr-only focus:not-sr-only focus:absolute focus:z-[60] focus:bg-white focus:px-4 focus:py-2 focus:text-[#68BD45] focus:rounded-lg focus:shadow-lg focus:top-2 focus:left-2">
+      <a href="#main-content" className="sr-only focus:not-sr-only focus:absolute focus:z-[60] focus:bg-white focus:px-4 focus:py-2 focus:text-[#045815] focus:rounded-lg focus:shadow-lg focus:top-2 focus:left-2">
         Skip to content
       </a>
       <Sidebar isAdmin={isAdmin} />
-      <main id="main-content" className="flex-1 pb-20 md:pb-0">
+      <MobileMenuDrawer isAdmin={isAdmin} />
+      <main id="main-content" className="flex-1 min-w-0 pb-20 md:pb-0">
         {children}
       </main>
       <BottomNav isAdmin={isAdmin} />

--- a/src/components/layout/page-header.tsx
+++ b/src/components/layout/page-header.tsx
@@ -7,9 +7,9 @@ interface PageHeaderProps {
 
 export function PageHeader({ title, actions }: PageHeaderProps) {
   return (
-    <div className="flex items-center justify-between px-4 py-4 md:px-6 md:py-6 border-b border-gray-200 bg-white shadow-sm">
-      <h1 className="text-xl md:text-2xl font-bold text-gray-900">{title}</h1>
-      {actions && <div className="flex items-center gap-2">{actions}</div>}
+    <div className="flex items-center justify-between gap-3 pl-16 pr-4 py-4 md:pl-6 md:pr-6 md:py-6 border-b border-gray-200 bg-white shadow-sm">
+      <h1 className="text-xl md:text-2xl font-bold text-gray-900 truncate">{title}</h1>
+      {actions && <div className="flex items-center gap-2 shrink-0">{actions}</div>}
     </div>
   )
 }

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -2,37 +2,21 @@
 
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
-import { LayoutDashboard, FolderOpen, FileStack, Settings, Clock, BarChart3, Activity, CalendarDays, HelpCircle, LogOut, Receipt, Package, FileText } from 'lucide-react'
+import { LogOut } from 'lucide-react'
 import { useSupabase } from '@/hooks/use-supabase'
 import { cn } from '@/lib/utils'
+import { visibleNavItems } from './nav-items'
 
 interface SidebarProps {
   isAdmin: boolean
 }
-
-const navItems = [
-  { href: '/dashboard', label: 'Dashboard', icon: LayoutDashboard, adminOnly: false },
-  { href: '/projects', label: 'Projects', icon: FolderOpen, adminOnly: false },
-  { href: '/my-time', label: 'My Time', icon: Clock, adminOnly: false },
-  { href: '/schedule', label: 'Schedule', icon: CalendarDays, adminOnly: false },
-  { href: '/reports', label: 'Reports', icon: BarChart3, adminOnly: true },
-  { href: '/quotes', label: 'Quotes', icon: FileText, adminOnly: true },
-  { href: '/invoices', label: 'Invoices', icon: Receipt, adminOnly: true },
-  { href: '/materials', label: 'Materials', icon: Package, adminOnly: true },
-  { href: '/activity', label: 'Activity', icon: Activity, adminOnly: false },
-  { href: '/templates', label: 'Templates', icon: FileStack, adminOnly: true },
-  { href: '/settings', label: 'Settings', icon: Settings, adminOnly: true },
-  { href: '/help', label: 'Help', icon: HelpCircle, adminOnly: false },
-]
 
 export function Sidebar({ isAdmin }: SidebarProps) {
   const pathname = usePathname()
   const router = useRouter()
   const supabase = useSupabase()
 
-  const visibleItems = navItems.filter(
-    (item) => !item.adminOnly || isAdmin
-  )
+  const items = visibleNavItems(isAdmin)
 
   async function handleLogout() {
     await supabase.auth.signOut()
@@ -42,22 +26,27 @@ export function Sidebar({ isAdmin }: SidebarProps) {
 
   return (
     <aside className="hidden md:flex md:flex-col md:w-64 bg-[#32373C] h-screen sticky top-0">
-      <div className="p-4 border-b border-white/10">
-        <img src="/brand/energi-logo-horizontal.png" alt="Energi Electric" className="h-8" />
+      <div className="p-4 bg-white border-b border-white/10">
+        <img
+          src="/brand/energi-logo-horizontal.png"
+          alt="Energi Electric"
+          className="h-8"
+        />
       </div>
 
       <nav aria-label="Main navigation" className="flex-1 p-3 space-y-1">
-        {visibleItems.map((item) => {
+        {items.map((item) => {
           const isActive = pathname.startsWith(item.href)
           return (
             <Link
               key={item.href}
               href={item.href}
+              aria-current={isActive ? 'page' : undefined}
               className={cn(
-                'flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors',
+                'flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-white/40',
                 isActive
-                  ? 'bg-[#68BD45]/15 text-[#68BD45]'
-                  : 'text-gray-400 hover:bg-white/5 hover:text-white'
+                  ? 'bg-[#045815] text-white shadow-sm'
+                  : 'text-gray-300 hover:bg-white/5 hover:text-white',
               )}
             >
               <item.icon className="w-5 h-5" />
@@ -70,7 +59,7 @@ export function Sidebar({ isAdmin }: SidebarProps) {
       <div className="p-3 border-t border-white/10">
         <button
           onClick={handleLogout}
-          className="flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium text-gray-400 hover:bg-white/5 hover:text-white transition-colors w-full"
+          className="flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium text-gray-300 hover:bg-white/5 hover:text-white transition-colors w-full focus:outline-none focus:ring-2 focus:ring-white/40"
         >
           <LogOut className="w-5 h-5" />
           Log Out

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -43,10 +43,10 @@ export function Sidebar({ isAdmin }: SidebarProps) {
               href={item.href}
               aria-current={isActive ? 'page' : undefined}
               className={cn(
-                'flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-white/40',
+                'flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-white/70',
                 isActive
                   ? 'bg-[#045815] text-white shadow-sm'
-                  : 'text-gray-300 hover:bg-white/5 hover:text-white',
+                  : 'text-gray-300 hover:bg-white/10 hover:text-white',
               )}
             >
               <item.icon className="w-5 h-5" />
@@ -59,7 +59,7 @@ export function Sidebar({ isAdmin }: SidebarProps) {
       <div className="p-3 border-t border-white/10">
         <button
           onClick={handleLogout}
-          className="flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium text-gray-300 hover:bg-white/5 hover:text-white transition-colors w-full focus:outline-none focus:ring-2 focus:ring-white/40"
+          className="flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium text-gray-300 hover:bg-white/10 hover:text-white transition-colors w-full focus:outline-none focus:ring-2 focus:ring-white/70"
         >
           <LogOut className="w-5 h-5" />
           Log Out

--- a/src/components/projects/customer-select.tsx
+++ b/src/components/projects/customer-select.tsx
@@ -70,7 +70,7 @@ export function CustomerSelect({ customers: initialCustomers, selectedId, onChan
         id="customer"
         value={selectedId ?? ''}
         onChange={(e) => onChange(e.target.value || null)}
-        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#68BD45] focus:border-transparent text-sm"
+        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#045815] focus:border-transparent text-sm"
       >
         <option value="">No customer</option>
         {customers.map((c) => (
@@ -84,7 +84,7 @@ export function CustomerSelect({ customers: initialCustomers, selectedId, onChan
         <button
           type="button"
           onClick={() => setShowNewForm(true)}
-          className="flex items-center gap-1 mt-2 text-sm text-[#68BD45] hover:text-[#5aa83c] transition-colors"
+          className="flex items-center gap-1 mt-2 text-sm text-[#045815] hover:text-[#023510] transition-colors"
         >
           <Plus className="w-3.5 h-3.5" /> Add new customer
         </button>

--- a/src/components/projects/phase-card.tsx
+++ b/src/components/projects/phase-card.tsx
@@ -73,7 +73,7 @@ export function PhaseCard({
                   className={cn(
                     'px-3 py-2 text-sm rounded-md border transition-colors',
                     phase.status === status
-                      ? 'border-[#045815] bg-[#045815]/10 text-[#045815]'
+                      ? 'border-[#045815] bg-[#045815]/15 text-[#023510]'
                       : 'border-gray-200 text-gray-500 hover:border-gray-300'
                   )}
                 >

--- a/src/components/projects/phase-card.tsx
+++ b/src/components/projects/phase-card.tsx
@@ -38,7 +38,7 @@ export function PhaseCard({
   return (
     <div className={cn(
       'border rounded-lg overflow-hidden',
-      phase.status === 'in_progress' ? 'border-[#68BD45]/30 bg-[#68BD45]/5' : 'border-gray-200 bg-white'
+      phase.status === 'in_progress' ? 'border-[#045815]/30 bg-[#045815]/5' : 'border-gray-200 bg-white'
     )}>
       <button
         onClick={() => setExpanded(!expanded)}
@@ -73,7 +73,7 @@ export function PhaseCard({
                   className={cn(
                     'px-3 py-2 text-sm rounded-md border transition-colors',
                     phase.status === status
-                      ? 'border-[#68BD45] bg-[#68BD45]/10 text-[#68BD45]'
+                      ? 'border-[#045815] bg-[#045815]/10 text-[#045815]'
                       : 'border-gray-200 text-gray-500 hover:border-gray-300'
                   )}
                 >

--- a/src/components/projects/phase-pipeline.tsx
+++ b/src/components/projects/phase-pipeline.tsx
@@ -15,7 +15,7 @@ const statusIcon = {
 
 const statusColor = {
   not_started: 'text-gray-500 border-gray-300',
-  in_progress: 'text-[#68BD45] border-[#68BD45] bg-[#68BD45]/10',
+  in_progress: 'text-[#045815] border-[#045815] bg-[#045815]/10',
   complete: 'text-green-600 border-green-600 bg-green-50',
 }
 

--- a/src/components/projects/project-card.tsx
+++ b/src/components/projects/project-card.tsx
@@ -62,7 +62,7 @@ export function ProjectCard({ project, phaseCount, completedPhases, hasUnread }:
             aria-label="Phase completion progress"
           >
             <div
-              className="bg-[#68BD45] h-1.5 rounded-full transition-all"
+              className="bg-[#045815] h-1.5 rounded-full transition-all"
               style={{ width: `${progress}%` }}
             />
           </div>

--- a/src/components/projects/project-form.tsx
+++ b/src/components/projects/project-form.tsx
@@ -153,7 +153,7 @@ export function ProjectForm({ templates, customers, userId }: ProjectFormProps) 
           id="template"
           value={templateId}
           onChange={(e) => setTemplateId(e.target.value)}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#68BD45] focus:border-transparent text-sm"
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#045815] focus:border-transparent text-sm"
         >
           <option value="">No template — start blank</option>
           {templates.map((t) => (
@@ -165,8 +165,8 @@ export function ProjectForm({ templates, customers, userId }: ProjectFormProps) 
       </div>
 
       {templateId && (
-        <div className="bg-[#68BD45]/10 rounded-lg p-3">
-          <p className="text-sm font-medium text-[#68BD45] mb-2">Phases from template:</p>
+        <div className="bg-[#045815]/10 rounded-lg p-3">
+          <p className="text-sm font-medium text-[#045815] mb-2">Phases from template:</p>
           <div className="flex flex-wrap gap-1">
             {templates
               .find((t) => t.id === templateId)
@@ -174,7 +174,7 @@ export function ProjectForm({ templates, customers, userId }: ProjectFormProps) 
               .map((phase) => (
                 <span
                   key={phase.id}
-                  className="px-2 py-0.5 bg-[#68BD45]/20 text-[#68BD45] text-xs rounded-full"
+                  className="px-2 py-0.5 bg-[#045815]/20 text-[#045815] text-xs rounded-full"
                 >
                   {phase.name}
                 </span>

--- a/src/components/reports/time-report-filters.tsx
+++ b/src/components/reports/time-report-filters.tsx
@@ -65,7 +65,7 @@ export function TimeReportFilters({ projects, workers }: TimeReportFiltersProps)
             id="project-filter"
             value={currentProject}
             onChange={(e) => updateFilter('project', e.target.value)}
-            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#68BD45] focus:border-transparent text-sm"
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#045815] focus:border-transparent text-sm"
           >
             <option value="">All Projects</option>
             {projects.map((p) => (
@@ -82,7 +82,7 @@ export function TimeReportFilters({ projects, workers }: TimeReportFiltersProps)
             id="worker-filter"
             value={currentWorker}
             onChange={(e) => updateFilter('worker', e.target.value)}
-            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#68BD45] focus:border-transparent text-sm"
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#045815] focus:border-transparent text-sm"
           >
             <option value="">All Workers</option>
             {workers.map((w) => (

--- a/src/components/reports/time-report-summary.tsx
+++ b/src/components/reports/time-report-summary.tsx
@@ -16,7 +16,7 @@ export function TimeReportSummary({
   uniqueWorkers,
 }: TimeReportSummaryProps) {
   const stats = [
-    { label: 'Total Hours', value: formatDuration(totalMinutes), icon: Clock, color: 'text-[#68BD45]' },
+    { label: 'Total Hours', value: formatDuration(totalMinutes), icon: Clock, color: 'text-[#045815]' },
     { label: 'Entries', value: String(entryCount), icon: FileText, color: 'text-green-500' },
     { label: 'Projects', value: String(uniqueProjects), icon: FolderOpen, color: 'text-purple-500' },
     { label: 'Workers', value: String(uniqueWorkers), icon: Users, color: 'text-orange-500' },

--- a/src/components/settings/notification-settings.tsx
+++ b/src/components/settings/notification-settings.tsx
@@ -105,7 +105,7 @@ export function NotificationSettings({ preferences, userId }: NotificationSettin
   return (
     <Card>
       <div className="flex items-center gap-2 mb-4">
-        <Bell className="w-5 h-5 text-[#68BD45]" />
+        <Bell className="w-5 h-5 text-[#045815]" />
         <h2 className="font-semibold text-gray-900">Notifications</h2>
       </div>
 
@@ -117,7 +117,7 @@ export function NotificationSettings({ preferences, userId }: NotificationSettin
           <button
             onClick={handleEnablePush}
             disabled={subscribing}
-            className="px-4 py-2 text-sm font-medium text-white bg-[#68BD45] rounded-lg hover:bg-[#5aa93d] transition-colors disabled:opacity-50"
+            className="px-4 py-2 text-sm font-medium text-white bg-[#045815] rounded-lg hover:bg-[#5aa93d] transition-colors disabled:opacity-50"
           >
             {subscribing ? 'Enabling...' : 'Enable Push Notifications'}
           </button>
@@ -134,7 +134,7 @@ export function NotificationSettings({ preferences, userId }: NotificationSettin
             <button
               onClick={() => handleToggle(key)}
               className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-                prefs?.[key] !== false ? 'bg-[#68BD45]' : 'bg-gray-300'
+                prefs?.[key] !== false ? 'bg-[#045815]' : 'bg-gray-300'
               }`}
               role="switch"
               aria-checked={prefs?.[key] !== false}

--- a/src/components/templates/phase-list-editor.tsx
+++ b/src/components/templates/phase-list-editor.tsx
@@ -114,7 +114,7 @@ export function PhaseListEditor({ phases, onChange }: PhaseListEditorProps) {
                 onClick={() => setExpandedPhaseId(expandedPhaseId === phase.id ? null : phase.id)}
                 aria-expanded={expandedPhaseId === phase.id}
                 aria-label={`${phase.name}, ${phase.tasks.length} task${phase.tasks.length !== 1 ? 's' : ''}, ${expandedPhaseId === phase.id ? 'collapse' : 'expand'}`}
-                className="flex-1 text-left text-sm font-medium text-gray-900 hover:text-[#68BD45] transition-colors flex items-center gap-1 cursor-pointer"
+                className="flex-1 text-left text-sm font-medium text-gray-900 hover:text-[#045815] transition-colors flex items-center gap-1 cursor-pointer"
               >
                 {phase.name}
                 <span className="text-xs text-gray-500 font-normal">
@@ -188,7 +188,7 @@ export function PhaseListEditor({ phases, onChange }: PhaseListEditorProps) {
                       setNewTaskTitles((prev) => ({ ...prev, [phase.id]: e.target.value }))
                     }
                     placeholder="Task title..."
-                    className="flex-1 px-2 py-1 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#68BD45] focus:border-transparent placeholder:text-gray-400"
+                    className="flex-1 px-2 py-1 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#045815] focus:border-transparent placeholder:text-gray-400"
                     onKeyDown={(e) => {
                       if (e.key === 'Enter') {
                         e.preventDefault()
@@ -200,7 +200,7 @@ export function PhaseListEditor({ phases, onChange }: PhaseListEditorProps) {
                     type="button"
                     onClick={() => addTask(phase.id)}
                     disabled={!newTaskTitles[phase.id]?.trim()}
-                    className="px-3 py-1 min-h-[44px] text-xs bg-[#68BD45] text-white rounded-lg hover:bg-[#5aa83c] disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+                    className="px-3 py-1 min-h-[44px] text-xs bg-[#045815] text-white rounded-lg hover:bg-[#023510] disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
                     aria-label={`Add task to ${phase.name}`}
                   >
                     Add

--- a/src/components/templates/template-form.tsx
+++ b/src/components/templates/template-form.tsx
@@ -159,7 +159,7 @@ export function TemplateForm({ template }: TemplateFormProps) {
           onChange={(e) => setDescription(e.target.value)}
           placeholder="What type of project is this template for?"
           rows={2}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#68BD45] focus:border-transparent text-sm placeholder:text-gray-400"
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#045815] focus:border-transparent text-sm placeholder:text-gray-400"
         />
       </div>
 

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -11,7 +11,7 @@ const variantStyles = {
   success: 'bg-green-100 text-green-700',
   warning: 'bg-yellow-100 text-yellow-700',
   danger: 'bg-red-100 text-red-700',
-  info: 'bg-[#045815]/10 text-[#045815]',
+  info: 'bg-[#045815]/15 text-[#023510]',
 }
 
 export function Badge({ children, variant = 'default', className }: BadgeProps) {

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -11,7 +11,7 @@ const variantStyles = {
   success: 'bg-green-100 text-green-700',
   warning: 'bg-yellow-100 text-yellow-700',
   danger: 'bg-red-100 text-red-700',
-  info: 'bg-[#68BD45]/10 text-[#68BD45]',
+  info: 'bg-[#045815]/10 text-[#045815]',
 }
 
 export function Badge({ children, variant = 'default', className }: BadgeProps) {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -15,8 +15,8 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         className={cn(
           'inline-flex items-center justify-center font-medium rounded-xl transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2',
           {
-            'bg-[#68BD45] text-white hover:bg-[#5aa83c] focus:ring-[#68BD45] shadow-sm hover:shadow-md': variant === 'primary',
-            'bg-white text-gray-700 border border-gray-300 hover:bg-gray-50 focus:ring-[#68BD45]': variant === 'secondary',
+            'bg-[#045815] text-white hover:bg-[#023510] focus:ring-[#045815] shadow-sm hover:shadow-md': variant === 'primary',
+            'bg-white text-gray-700 border border-gray-300 hover:bg-gray-50 focus:ring-[#045815]': variant === 'secondary',
             'bg-red-600 text-white hover:bg-red-700 focus:ring-red-500': variant === 'danger',
             'text-gray-600 hover:bg-gray-100 hover:text-gray-900 focus:ring-gray-500': variant === 'ghost',
           },

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -13,7 +13,7 @@ export function Card({ children, className, onClick, hoverable }: CardProps) {
     <div
       className={cn(
         'bg-white rounded-lg border border-gray-200 shadow-sm p-4',
-        hoverable && 'hover:shadow-md hover:border-[#68BD45]/30 transition-all cursor-pointer',
+        hoverable && 'hover:shadow-md hover:border-[#045815]/30 transition-all cursor-pointer',
         onClick && 'cursor-pointer',
         className
       )}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -22,7 +22,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             'w-full px-3 py-2 border rounded-lg focus:ring-2 focus:border-transparent text-sm placeholder:text-gray-400',
             error
               ? 'border-red-300 focus:ring-red-500'
-              : 'border-gray-300 focus:ring-[#68BD45]',
+              : 'border-gray-300 focus:ring-[#045815]',
             className
           )}
           {...props}

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -40,14 +40,14 @@ export async function sendPortalShareEmail({
           <p style="font-size: 16px; line-height: 1.6;">
             Blue Shores Electric has set up a portal for you to view your project status and invoices.
           </p>
-          <a href="${portalUrl}" style="display: inline-block; background-color: #68BD45; color: white; padding: 14px 28px; border-radius: 8px; text-decoration: none; font-weight: bold; font-size: 16px; margin: 16px 0;">
+          <a href="${portalUrl}" style="display: inline-block; background-color: #045815; color: white; padding: 14px 28px; border-radius: 8px; text-decoration: none; font-weight: bold; font-size: 16px; margin: 16px 0;">
             View My Portal
           </a>
           <p style="font-size: 14px; color: #666; margin-top: 24px;">
             Bookmark this link — you can use it anytime to check on your project and view invoices.
           </p>
           <p style="font-size: 14px; color: #666;">
-            Questions? Call us at <a href="tel:9106192000" style="color: #68BD45;">(910) 619-2000</a>
+            Questions? Call us at <a href="tel:9106192000" style="color: #045815;">(910) 619-2000</a>
           </p>
           <hr style="border: none; border-top: 1px solid #eee; margin: 24px 0;" />
           <p style="font-size: 12px; color: #999;">Blue Shores Electric · Wilmington, NC</p>
@@ -96,14 +96,14 @@ export async function sendInvoiceNotificationEmail({
           <div style="background: #f9f9f9; border-radius: 8px; padding: 20px; margin: 20px 0;">
             <p style="margin: 0 0 8px; font-size: 14px; color: #666;">Invoice #${invoiceNumber}</p>
             <p style="margin: 0 0 8px; font-size: 18px; font-weight: bold; color: #32373C;">${invoiceTitle}</p>
-            <p style="margin: 0 0 8px; font-size: 24px; font-weight: bold; color: #68BD45;">${formattedTotal}</p>
+            <p style="margin: 0 0 8px; font-size: 24px; font-weight: bold; color: #045815;">${formattedTotal}</p>
             ${formattedDue ? `<p style="margin: 0; font-size: 14px; color: #666;">Due: ${formattedDue}</p>` : ''}
           </div>
-          <a href="${portalUrl}" style="display: inline-block; background-color: #68BD45; color: white; padding: 14px 28px; border-radius: 8px; text-decoration: none; font-weight: bold; font-size: 16px; margin: 16px 0;">
+          <a href="${portalUrl}" style="display: inline-block; background-color: #045815; color: white; padding: 14px 28px; border-radius: 8px; text-decoration: none; font-weight: bold; font-size: 16px; margin: 16px 0;">
             View Invoice
           </a>
           <p style="font-size: 14px; color: #666; margin-top: 24px;">
-            Questions? Call us at <a href="tel:9106192000" style="color: #68BD45;">(910) 619-2000</a>
+            Questions? Call us at <a href="tel:9106192000" style="color: #045815;">(910) 619-2000</a>
           </p>
           <hr style="border: none; border-top: 1px solid #eee; margin: 24px 0;" />
           <p style="font-size: 12px; color: #999;">Blue Shores Electric · Wilmington, NC</p>

--- a/src/lib/pdf.tsx
+++ b/src/lib/pdf.tsx
@@ -29,7 +29,7 @@ const styles = StyleSheet.create({
   totalsLabel: { fontSize: 11, color: '#6b7280', width: 120, textAlign: 'right', paddingRight: 12 },
   totalsValue: { fontSize: 11, color: '#374151', width: 80, textAlign: 'right' },
   grandLabel: { fontSize: 13, fontFamily: 'Helvetica-Bold', color: '#32373C', width: 120, textAlign: 'right', paddingRight: 12 },
-  grandValue: { fontSize: 13, fontFamily: 'Helvetica-Bold', color: '#68BD45', width: 80, textAlign: 'right' },
+  grandValue: { fontSize: 13, fontFamily: 'Helvetica-Bold', color: '#045815', width: 80, textAlign: 'right' },
   notes: { marginTop: 20, fontSize: 10, color: '#555', backgroundColor: '#f9fafb', padding: 10, borderRadius: 4 },
   notesLabel: { fontSize: 9, color: '#888', textTransform: 'uppercase', letterSpacing: 0.5, marginBottom: 4 },
   footer: { position: 'absolute', bottom: 32, left: 40, right: 40, textAlign: 'center', fontSize: 9, color: '#9ca3af' },


### PR DESCRIPTION
## Summary

Cleanup pass against the 2026-04-25 visual UX audit. Two commits.

### `09a2afe` — initial cleanup
1. **Mobile admin nav** — new `MobileMenuDrawer` (hamburger top-left, slide-in panel). Mirrors the desktop sidebar so admins on mobile can finally reach Quotes / Materials / Invoices / Settings / Reports / Activity / Templates. Bottom nav stays as-is for crew.
2. **Schedule overflow** — `min-w-0` on `<main>` + the schedule wrapper so the existing `overflow-x-auto` actually constrains width.
3. **Brand color sweep** — global find/replace `#68BD45` → `#045815`, `#5aa83c` → `#023510`. 136 occurrences across 51 files. Plus sidebar active state redesigned to solid `bg-[#045815] text-white` pill (was tint-on-tint, invisible on dark sidebar). Logo container goes white-bg so the dark-text logo asset reads.
4. **Dead `/customers` link** in `/quotes/new` — copy + target now point at `/projects` ("Customers are created during project setup — start a project to add one.").
5. **Invoices list parity** with quotes — wrap-friendly toolbar + centered "+ New invoice" CTA in the empty card.

### `3568663` — aesthetic review fixes
- **Drawer focus trap** — focus close button on open, Tab/Shift-Tab cycles, Esc preventDefault'd, focus restored to hamburger on close, `aria-modal="true"`, `inert` while closed (no Tab leak to hidden links).
- **Hamburger overlap** on non-PageHeader screens — `pt-14 md:pt-0` on `<main>` so all pages clear the fixed top-3 button.
- **Hamburger visibility** — was `bg-white` on white PageHeader (invisible). Now solid `bg-[#32373C] text-white` so it reads as a control.
- **Badge `info` + freestanding tint-on-tint contrast** — `bg-[#045815]/10 text-[#045815]` (~3.4:1, fail AA) → `bg-[#045815]/15 text-[#023510]` (clears AA). Sweeps Badge, drawing-tools, symbol-toolbar, phase-card.
- **Schedule today highlight** — `bg-[#045815]/5` was nearly imperceptible; bumped to `bg-[#045815]/10 ring-1 ring-[#045815]/20` (today + selected variants).
- **Sidebar polish** — `hover:bg-white/5` → `/10`; `focus:ring-white/40` → `/70`.
- **Drawer width** — `w-72` → `w-[85vw] max-w-xs` so backdrop reads as tappable on 320px.

## Closes

- BlueWaveCreative/Operations#8 — customer portal rebrand
- BlueWaveCreative/Operations#9 — admin dashboard + projects token application
- BlueWaveCreative/Operations#10 — admin invoices + customers token application
- BlueWaveCreative/Operations#11 — admin settings + reports token application
- BlueWaveCreative/Operations#13 — final M1 verification

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run tests/lib` — 45/45
- [x] Zero `#68BD45` / `#5aa83c` remain in `src/`
- [ ] Live Playwright re-walk of the preview deploy: desktop + mobile, covering dashboard, quotes, materials, invoices, schedule, settings, /quotes/new — expecting hamburger to work, drawer to focus-trap, contrast to read, schedule to scroll, no dead `/customers` link

🤖 Generated with [Claude Code](https://claude.com/claude-code)